### PR TITLE
Fixed benchmark_duration and dataset_load_duration timeseries by version are not checking Null version label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.4.9"
+version = "0.4.10"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>"]
 readme = "README.md"

--- a/redisbench_admin/run/redistimeseries.py
+++ b/redisbench_admin/run/redistimeseries.py
@@ -236,6 +236,7 @@ def timeseries_test_sucess_flow(
                     tf_github_repo,
                     tf_triggering_env,
                 )
+            if artifact_version is not None and artifact_version != "":
                 add_standardized_metric_byversion(
                     "benchmark_duration",
                     benchmark_duration_seconds,

--- a/redisbench_admin/run/redistimeseries.py
+++ b/redisbench_admin/run/redistimeseries.py
@@ -236,30 +236,30 @@ def timeseries_test_sucess_flow(
                     tf_github_repo,
                     tf_triggering_env,
                 )
-            add_standardized_metric_byversion(
-                "benchmark_duration",
-                benchmark_duration_seconds,
-                artifact_version,
-                deployment_type,
-                rts,
-                start_time_ms,
-                test_name,
-                tf_github_org,
-                tf_github_repo,
-                tf_triggering_env,
-            )
-            add_standardized_metric_byversion(
-                "dataset_load_duration",
-                dataset_load_duration_seconds,
-                artifact_version,
-                deployment_type,
-                rts,
-                start_time_ms,
-                test_name,
-                tf_github_org,
-                tf_github_repo,
-                tf_triggering_env,
-            )
+                add_standardized_metric_byversion(
+                    "benchmark_duration",
+                    benchmark_duration_seconds,
+                    artifact_version,
+                    deployment_type,
+                    rts,
+                    start_time_ms,
+                    test_name,
+                    tf_github_org,
+                    tf_github_repo,
+                    tf_triggering_env,
+                )
+                add_standardized_metric_byversion(
+                    "dataset_load_duration",
+                    dataset_load_duration_seconds,
+                    artifact_version,
+                    deployment_type,
+                    rts,
+                    start_time_ms,
+                    test_name,
+                    tf_github_org,
+                    tf_github_repo,
+                    tf_triggering_env,
+                )
         except redis.exceptions.ResponseError as e:
             logging.warning(
                 "Error while updating secondary data structures {}. ".format(


### PR DESCRIPTION
Fixed benchmark_duration and dataset_load_duration timeseries by version are not checking Null version label

