### PR TITLE
Enable redisbench-admin compare by tag/branch

### DIFF
--- a/redisbench_admin/compare/args.py
+++ b/redisbench_admin/compare/args.py
@@ -41,8 +41,10 @@ def create_compare_arguments(parser):
     parser.add_argument("--deployment_type", type=str, default="oss-standalone")
     parser.add_argument("--metric_name", type=str, default="Tests.Overall.rps")
     parser.add_argument("--metric_mode", type=str, default="higher-better")
-    parser.add_argument("--baseline-branch", type=str, default=None, required=True)
-    parser.add_argument("--comparison-branch", type=str, default=None, required=True)
+    parser.add_argument("--baseline-branch", type=str, default=None, required=False)
+    parser.add_argument("--baseline-tag", type=str, default=None, required=False)
+    parser.add_argument("--comparison-branch", type=str, default=None, required=False)
+    parser.add_argument("--comparison-tag", type=str, default=None, required=False)
     parser.add_argument("--print-regressions-only", type=bool, default=False)
     parser.add_argument(
         "--regressions-percent-lower-limit",


### PR DESCRIPTION
Fixes #217
Example:
```
TRIGGERING_ENV=circleci poetry run redisbench-admin compare --baseline-tag 20000 --comparison-tag 20002  --github_repo RedisJSON --github_org RedisJSON
```