### PR TITLE
Enabled per module configuration parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.6.8"
+version = "0.6.9"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/commands/__init__.py
+++ b/redisbench_admin/commands/__init__.py
@@ -1,0 +1,5 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2022., Redis Labs Modules
+#  All rights reserved.
+#

--- a/redisbench_admin/commands/commands.json.py
+++ b/redisbench_admin/commands/commands.json.py
@@ -1,0 +1,5 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2022., Redis Labs Modules
+#  All rights reserved.
+#

--- a/redisbench_admin/environments/oss_standalone.py
+++ b/redisbench_admin/environments/oss_standalone.py
@@ -4,12 +4,11 @@
 #  All rights reserved.
 #
 import logging
-import os
 import subprocess
 
 import redis
 
-from redisbench_admin.utils.utils import wait_for_conn
+from redisbench_admin.utils.utils import wait_for_conn, redis_server_config_module_part
 
 
 def spin_up_local_redis(
@@ -20,9 +19,15 @@ def spin_up_local_redis(
     configuration_parameters=None,
     dbdir_folder=None,
     dataset_load_timeout_secs=120,
+    modules_configuration_parameters_map={},
 ):
     command = generate_standalone_redis_server_args(
-        binary, dbdir, local_module_files, port, configuration_parameters
+        binary,
+        dbdir,
+        local_module_files,
+        port,
+        configuration_parameters,
+        modules_configuration_parameters_map,
     )
 
     logging.info(
@@ -38,7 +43,12 @@ def spin_up_local_redis(
 
 
 def generate_standalone_redis_server_args(
-    binary, dbdir, local_module_files, port, configuration_parameters=None
+    binary,
+    dbdir,
+    local_module_files,
+    port,
+    configuration_parameters=None,
+    modules_configuration_parameters_map={},
 ):
     # start redis-server
     command = [
@@ -60,18 +70,12 @@ def generate_standalone_redis_server_args(
             )
     if local_module_files is not None:
         if type(local_module_files) == str:
-            command.extend(
-                [
-                    "--loadmodule",
-                    os.path.abspath(local_module_files),
-                ]
+            redis_server_config_module_part(
+                command, local_module_files, modules_configuration_parameters_map
             )
         if type(local_module_files) == list:
             for mod in local_module_files:
-                command.extend(
-                    [
-                        "--loadmodule",
-                        os.path.abspath(mod),
-                    ]
+                redis_server_config_module_part(
+                    command, mod, modules_configuration_parameters_map
                 )
     return command

--- a/redisbench_admin/run/cluster.py
+++ b/redisbench_admin/run/cluster.py
@@ -111,6 +111,7 @@ def spin_up_redis_cluster_remote_redis(
     shard_count,
     start_port,
     ssh_port,
+    modules_configuration_parameters_map,
 ):
     logging.info("Generating the remote redis-server command arguments")
     redis_process_commands = []
@@ -123,6 +124,7 @@ def spin_up_redis_cluster_remote_redis(
             server_private_ip,
             shard_port,
             redis_configuration_parameters,
+            modules_configuration_parameters_map,
         )
         logging.error(
             "Remote primary shard {} command: {}".format(

--- a/redisbench_admin/run/run.py
+++ b/redisbench_admin/run/run.py
@@ -42,7 +42,7 @@ def define_benchmark_plan(benchmark_definitions, default_specs):
             benchmark_runs_plan[benchmark_type] = {}
 
         # extract dataset-name
-        dbconfig_present, dataset_name, _, _ = extract_redis_dbconfig_parameters(
+        dbconfig_present, dataset_name, _, _, _ = extract_redis_dbconfig_parameters(
             benchmark_config, "dbconfig"
         )
         if dataset_name is None:

--- a/redisbench_admin/run_local/local_db.py
+++ b/redisbench_admin/run_local/local_db.py
@@ -68,6 +68,7 @@ def local_db_spin(
         _,
         redis_configuration_parameters,
         dataset_load_timeout_secs,
+        modules_configuration_parameters_map,
     ) = extract_redis_dbconfig_parameters(benchmark_config, "dbconfig")
     cluster_api_enabled = False
     logging.info(
@@ -85,6 +86,7 @@ def local_db_spin(
             local_module_file,
             redis_configuration_parameters,
             dataset_load_timeout_secs,
+            modules_configuration_parameters_map,
         )
 
         status = setup_redis_cluster_from_conns(
@@ -111,6 +113,7 @@ def local_db_spin(
             redis_configuration_parameters,
             dbdir_folder,
             dataset_load_timeout_secs,
+            modules_configuration_parameters_map,
         )
 
         r = redis.StrictRedis(port=args.port)

--- a/redisbench_admin/run_remote/remote_db.py
+++ b/redisbench_admin/run_remote/remote_db.py
@@ -90,6 +90,7 @@ def remote_db_spin(
         _,
         redis_configuration_parameters,
         dataset_load_timeout_secs,
+        modules_configuration_parameters_map,
     ) = extract_redis_dbconfig_parameters(benchmark_config, "dbconfig")
 
     cluster_start_port = 20000
@@ -129,6 +130,7 @@ def remote_db_spin(
             shard_count,
             cluster_start_port,
             db_ssh_port,
+            modules_configuration_parameters_map,
         )
 
         for p in range(cluster_start_port, cluster_start_port + shard_count):
@@ -153,6 +155,7 @@ def remote_db_spin(
             logname,
             redis_configuration_parameters,
             db_ssh_port,
+            modules_configuration_parameters_map,
         )
         full_logfiles.append(full_logfile)
         local_redis_conn, ssh_tunnel = ssh_tunnel_redisconn(

--- a/redisbench_admin/utils/benchmark_config.py
+++ b/redisbench_admin/utils/benchmark_config.py
@@ -173,6 +173,7 @@ def merge_default_and_specific_properties_dict_type(
 
 def extract_redis_dbconfig_parameters(benchmark_config, dbconfig_keyname):
     redis_configuration_parameters = {}
+    modules_configuration_parameters_map = {}
     dataset_load_timeout_secs = 120
     dataset_name = None
     dbconfig_present = False
@@ -180,6 +181,10 @@ def extract_redis_dbconfig_parameters(benchmark_config, dbconfig_keyname):
         dbconfig_present = True
         if type(benchmark_config[dbconfig_keyname]) == list:
             for k in benchmark_config[dbconfig_keyname]:
+                if "module-configuration-parameters" in k:
+                    modules_configuration_parameters_map = k[
+                        "module-configuration-parameters"
+                    ]
                 if "configuration-parameters" in k:
                     cp = k["configuration-parameters"]
                     for item in cp:
@@ -190,6 +195,10 @@ def extract_redis_dbconfig_parameters(benchmark_config, dbconfig_keyname):
                 if "dataset_name" in k:
                     dataset_name = k["dataset_name"]
         if type(benchmark_config[dbconfig_keyname]) == dict:
+            if "module-configuration-parameters" in benchmark_config[dbconfig_keyname]:
+                modules_configuration_parameters_map = benchmark_config[
+                    dbconfig_keyname
+                ]["module-configuration-parameters"]
             if "configuration-parameters" in benchmark_config[dbconfig_keyname]:
                 cp = benchmark_config[dbconfig_keyname]["configuration-parameters"]
                 for k, v in cp.items():
@@ -204,6 +213,7 @@ def extract_redis_dbconfig_parameters(benchmark_config, dbconfig_keyname):
         dataset_name,
         redis_configuration_parameters,
         dataset_load_timeout_secs,
+        modules_configuration_parameters_map,
     )
 
 

--- a/redisbench_admin/utils/utils.py
+++ b/redisbench_admin/utils/utils.py
@@ -25,6 +25,36 @@ from tqdm import tqdm
 EPOCH = dt.datetime.utcfromtimestamp(0)
 
 
+def redis_server_config_module_part(
+    command, local_module_file, modules_configuration_parameters_map
+):
+    command.extend(
+        [
+            "--loadmodule",
+            os.path.abspath(local_module_file),
+        ]
+    )
+    for (
+        module_config_modulename,
+        module_config_dict,
+    ) in modules_configuration_parameters_map.items():
+        if module_config_modulename in local_module_file:
+            for (
+                module_config_parameter_name,
+                module_config_parameter_value,
+            ) in module_config_dict.items():
+                if type(module_config_parameter_value) != str:
+                    module_config_parameter_value = "{}".format(
+                        module_config_parameter_value
+                    )
+                command.extend(
+                    [
+                        module_config_parameter_name,
+                        module_config_parameter_value,
+                    ]
+                )
+
+
 def upload_artifacts_to_s3(
     artifacts,
     s3_bucket_name,

--- a/tests/test_benchmark_config.py
+++ b/tests/test_benchmark_config.py
@@ -56,8 +56,10 @@ def test_extract_redis_configuration_parameters():
             _,
             redis_configuration_parameters,
             dataset_load_timeout_secs,
+            modules_configuration_parameters_map,
         ) = extract_redis_dbconfig_parameters(benchmark_config, "dbconfig")
         assert redis_configuration_parameters == {}
+        assert modules_configuration_parameters_map == {}
         assert dataset_load_timeout_secs == 120
         assert dbconfig_present == False
 
@@ -70,8 +72,10 @@ def test_extract_redis_configuration_parameters():
             _,
             redis_configuration_parameters,
             dataset_load_timeout_secs,
+            modules_configuration_parameters_map,
         ) = extract_redis_dbconfig_parameters(benchmark_config, "dbconfig")
         assert dataset_load_timeout_secs == 120
+        assert modules_configuration_parameters_map == {}
         assert dbconfig_present == True
         assert redis_configuration_parameters == {
             "notify-keyspace-events": "KEA",
@@ -87,6 +91,25 @@ def test_extract_redis_configuration_parameters():
             _,
             redis_configuration_parameters,
             dataset_load_timeout_secs,
+            modules_configuration_parameters_map,
         ) = extract_redis_dbconfig_parameters(benchmark_config, "dbconfig")
         assert dataset_load_timeout_secs == 1200
+        assert modules_configuration_parameters_map == {}
+        assert dbconfig_present == True
+
+    with open(
+        "./tests/test_data/tsbs-scale100-cpu-max-all-1@4139rps.yml", "r"
+    ) as config_fd:
+        benchmark_config = yaml.safe_load(config_fd)
+        (
+            dbconfig_present,
+            _,
+            redis_configuration_parameters,
+            dataset_load_timeout_secs,
+            modules_configuration_parameters_map,
+        ) = extract_redis_dbconfig_parameters(benchmark_config, "dbconfig")
+        assert dataset_load_timeout_secs == 120
+        assert modules_configuration_parameters_map == {
+            "redistimeseries": {"CHUNK_SIZE_BYTES": 128}
+        }
         assert dbconfig_present == True

--- a/tests/test_data/tsbs-scale100-cpu-max-all-1@4139rps.yml
+++ b/tests/test_data/tsbs-scale100-cpu-max-all-1@4139rps.yml
@@ -1,0 +1,46 @@
+version: 0.5
+name: "tsbs-scale100-cpu-max-all-1@4139rps"
+
+metadata:
+  labels:
+    test_type: query
+    includes_targets: "true"
+
+remote:
+  - type: oss-standalone
+  - setup: redistimeseries-m5
+
+setups:
+  - oss-cluster-05-primaries
+  - oss-cluster-15-primaries
+  - oss-cluster-30-primaries
+
+dbconfig:
+  - dataset_name: "data_redistimeseries_cpu-only_100"
+  - tool: tsbs_load_redistimeseries
+  - parameters:
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
+  - check:
+      keyspacelen: 1000
+  - module-configuration-parameters:
+      redistimeseries:
+        CHUNK_SIZE_BYTES: 128
+
+clientconfig:
+  - benchmark_type: "read-only"
+  - tool: tsbs_run_queries_redistimeseries
+  - parameters:
+    - workers: 32
+    - max-rps: 4139
+    - print-interval: 2500
+    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/queries/devops/scale100/devops-scale100-4days/queries_cpu-only_redistimeseries_100_cpu-max-all-1_1000000.dat"
+
+exporter:
+  redistimeseries:
+    metrics:
+      - "$.Totals.overallQuantiles.all_queries.q50":
+          "target-1": 7.18
+          "target-2": 8.31
+      - "$.Totals.overallQueryRates.all_queries":
+          "target-1": 4139
+          "target-2": 4139

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -67,6 +67,28 @@ def test_generate_standalone_redis_server_args():
         "--loadmodule",
         os.path.abspath(local_module_file),
     ]
+
+    cmd = generate_standalone_redis_server_args(
+        "redis-server",
+        ".",
+        local_module_file,
+        "1010",
+        {"m1": {"CHUNK_SIZE_BYTES": 128}},
+    )
+    assert cmd == [
+        "redis-server",
+        "--save",
+        '""',
+        "--port",
+        "1010",
+        "--dir",
+        ".",
+        "--loadmodule",
+        os.path.abspath(local_module_file),
+        "CHUNK_SIZE_BYTES",
+        "128",
+    ]
+
     cmd = generate_standalone_redis_server_args(
         "redis-server", ".", None, "9999", {"notify-keyspace-events": "KEA"}
     )

--- a/tests/test_standalone.py
+++ b/tests/test_standalone.py
@@ -12,6 +12,7 @@ import yaml
 
 from redisbench_admin.run_remote.standalone import (
     spin_up_standalone_remote_redis,
+    generate_remote_standalone_redis_cmd,
 )
 
 
@@ -64,3 +65,15 @@ def test_spin_up_standalone_remote_redis():
         None,
         port,
     )
+
+
+def test_generate_remote_standalone_redis_cmd():
+    modules_configuration_parameters_map = {"m1": {"CHUNK_SIZE_BYTES": 128}}
+    full_logfile, initial_redis_cmd = generate_remote_standalone_redis_cmd(
+        "log1",
+        None,
+        ["m1.so"],
+        ".",
+        modules_configuration_parameters_map,
+    )
+    assert initial_redis_cmd.endswith("m1.so CHUNK_SIZE_BYTES 128")


### PR DESCRIPTION
Sample config block:
```
(...)

dbconfig:
  - dataset_name: "data_redistimeseries_cpu-only_100"
  - tool: tsbs_load_redistimeseries
  - parameters:
    - file: "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/scale100/data_redistimeseries_cpu-only_100.dat"
  - check:
      keyspacelen: 1000
  - module-configuration-parameters:
      redistimeseries:
        CHUNK_SIZE_BYTES: 128
(...)
```