### PR TITLE
fix: clarify local vs remote dir paths and fix artifact download bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.13"
+version = "0.12.14"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run_remote/remote_db.py
+++ b/redisbench_admin/run_remote/remote_db.py
@@ -41,19 +41,19 @@ from redisbench_admin.utils.utils import setup_search_clusterset
 
 
 def remote_tmpdir_prune(
-    server_public_ip, ssh_port, temporary_dir, username, private_key
+    server_public_ip, ssh_port, remote_temporary_dir, username, private_key
 ):
     execute_remote_commands(
         server_public_ip,
         username,
         private_key,
         [
-            "mkdir -p {}".format(temporary_dir),
-            "rm -rf {}/*.log".format(temporary_dir),
-            "rm -rf {}/*.config".format(temporary_dir),
-            "rm -rf {}/*.rdb".format(temporary_dir),
-            "rm -rf {}/*.out".format(temporary_dir),
-            "rm -rf {}/*.data".format(temporary_dir),
+            "mkdir -p {}".format(remote_temporary_dir),
+            "rm -rf {}/*.log".format(remote_temporary_dir),
+            "rm -rf {}/*.config".format(remote_temporary_dir),
+            "rm -rf {}/*.rdb".format(remote_temporary_dir),
+            "rm -rf {}/*.out".format(remote_temporary_dir),
+            "rm -rf {}/*.data".format(remote_temporary_dir),
             "pkill -9 redis-server",
         ],
         ssh_port,
@@ -73,7 +73,8 @@ def remote_db_spin(
     client_public_ip,
     clusterconfig,
     dbdir_folder,
-    dirname,
+    remote_db_dir,
+    local_output_dir,
     local_module_files,
     logname,
     required_modules,
@@ -86,7 +87,7 @@ def remote_db_spin(
     shard_count,
     db_ssh_port,
     client_ssh_port,
-    temporary_dir,
+    remote_temporary_dir,
     test_name,
     testcase_start_time_str,
     tf_github_branch,
@@ -111,6 +112,18 @@ def remote_db_spin(
     extra_libs=None,
     custom_redis_server_path=None,
 ):
+    """Spin up Redis on the remote DB server and prepare it for benchmarking.
+
+    Args:
+        remote_db_dir: Base directory on the *remote DB server* where Redis
+            stores its working data (e.g. ``/mnt/flash``).  Used to locate
+            dataset files that already exist on the DB server.
+        local_output_dir: Directory on the *local driver* machine where
+            error artifacts will be saved when something goes wrong.
+        remote_temporary_dir: Random subdirectory under *remote_db_dir* on the
+            remote DB server used as the Redis working directory
+            (e.g. ``/mnt/flash/<random>``).
+    """
     (
         _,
         _,
@@ -128,7 +141,7 @@ def remote_db_spin(
             dbdir_folder,
             private_key,
             server_public_ip,
-            temporary_dir,
+            remote_temporary_dir,
             username,
         )
         logging.info("Checking if there are modules we need to cp to remote host...")
@@ -173,7 +186,7 @@ def remote_db_spin(
                 private_key,
                 remote_module_files,
                 redis_configuration_parameters,
-                temporary_dir,
+                remote_temporary_dir,
                 shard_count,
                 cluster_start_port,
                 db_ssh_port,
@@ -201,20 +214,20 @@ def remote_db_spin(
             logging.error("A error occurred while spinning DB: {}".format(e.__str__()))
             logfile = logfiles[0]
 
-            remote_file = "{}/{}".format(temporary_dir, logfile)
+            remote_file = "{}/{}".format(remote_temporary_dir, logfile)
             logging.error(
                 "Trying to fetch DB remote log {} into {}".format(remote_file, logfile)
             )
             db_error_artifacts(
                 db_ssh_port,
-                dirname,
+                local_output_dir,
                 full_logfiles,
                 logname,
                 private_key,
                 s3_bucket_name,
                 s3_bucket_path,
                 server_public_ip,
-                temporary_dir,
+                remote_temporary_dir,
                 True,
                 username,
             )
@@ -223,7 +236,7 @@ def remote_db_spin(
         try:
             if skip_redis_setup is False:
                 full_logfile = spin_up_standalone_remote_redis(
-                    temporary_dir,
+                    remote_temporary_dir,
                     server_public_ip,
                     username,
                     private_key,
@@ -252,14 +265,14 @@ def remote_db_spin(
             logging.error("A error occurred while spinning DB: {}".format(e.__str__()))
             db_error_artifacts(
                 db_ssh_port,
-                dirname,
+                local_output_dir,
                 full_logfiles,
                 logname,
                 private_key,
                 s3_bucket_name,
                 s3_bucket_path,
                 server_public_ip,
-                temporary_dir,
+                remote_temporary_dir,
                 True,
                 username,
             )
@@ -323,8 +336,8 @@ def remote_db_spin(
         server_public_ip,
         username,
         private_key,
-        temporary_dir,
-        dirname,
+        remote_temporary_dir,
+        remote_db_dir,
         shard_count,
         cluster_enabled,
         cluster_start_port,
@@ -406,14 +419,14 @@ def remote_db_spin(
         logging.error("Remote redis is not available")
         db_error_artifacts(
             db_ssh_port,
-            dirname,
+            local_output_dir,
             full_logfiles,
             logname,
             private_key,
             s3_bucket_name,
             s3_bucket_path,
             server_public_ip,
-            temporary_dir,
+            remote_temporary_dir,
             True,
             username,
         )
@@ -449,17 +462,34 @@ def remote_db_spin(
 
 def db_error_artifacts(
     db_ssh_port,
-    dirname,
+    local_output_dir,
     full_logfiles,
     logname,
     private_key,
     s3_bucket_name,
     s3_bucket_path,
     server_public_ip,
-    temporary_dir,
+    remote_temporary_dir,
     upload_s3,
     username,
 ):
+    """Fetch error artifacts from the remote DB server and optionally upload to S3.
+
+    Args:
+        db_ssh_port: SSH port of the DB server.
+        local_output_dir: Local (driver) directory where fetched artifacts will
+            be stored.  Must be a path on the machine running redisbench-admin.
+        full_logfiles: List of remote log file paths on the DB server.
+        logname: Base log name used for the zip / log filenames.
+        private_key: SSH private key path.
+        s3_bucket_name: S3 bucket name.
+        s3_bucket_path: S3 key prefix.
+        server_public_ip: Public IP of the DB server.
+        remote_temporary_dir: Working directory on the *remote DB server*
+            (e.g. ``/mnt/flash/<random>``).
+        upload_s3: Whether to upload to S3.
+        username: SSH user for the DB server.
+    """
     # Import the zip check function
     from redisbench_admin.run_remote.standalone import ensure_zip_available
 
@@ -475,7 +505,7 @@ def db_error_artifacts(
         username,
         private_key,
         [
-            "zip -r {} {}/*".format(remote_zipfile, temporary_dir),
+            "zip -r {} {}/*".format(remote_zipfile, remote_temporary_dir),
         ],
         db_ssh_port,
     )
@@ -498,7 +528,7 @@ def db_error_artifacts(
             failed_remote_run_artifact_store(
                 upload_s3,
                 server_public_ip,
-                dirname,
+                local_output_dir,
                 remote_zipfile,
                 local_zipfile,
                 s3_bucket_name,
@@ -519,7 +549,7 @@ def db_error_artifacts(
             failed_remote_run_artifact_store(
                 upload_s3,
                 server_public_ip,
-                dirname,
+                local_output_dir,
                 full_logfiles[0],
                 logname,
                 s3_bucket_name,

--- a/redisbench_admin/run_remote/remote_failures.py
+++ b/redisbench_admin/run_remote/remote_failures.py
@@ -13,7 +13,7 @@ from redisbench_admin.utils.utils import upload_artifacts_to_s3
 def failed_remote_run_artifact_store(
     upload_results_s3,
     client_public_ip,
-    dirname,
+    local_output_dir,
     remote_file,
     local_file,
     s3_bucket_name,
@@ -21,7 +21,23 @@ def failed_remote_run_artifact_store(
     username,
     private_key,
 ):
-    local_file_fullpath = "{}/{}".format(dirname, local_file)
+    """Fetch a file from a remote server and optionally upload it to S3.
+
+    Args:
+        upload_results_s3: Whether to upload fetched artifacts to S3.
+        client_public_ip: Public IP of the remote server to fetch from.
+        local_output_dir: Local (driver) directory where the fetched file will
+            be stored.  This must be a path on the machine running
+            redisbench-admin, **not** a path on the remote server.
+        remote_file: Absolute path of the file on the remote server.
+        local_file: Basename used for the local copy (combined with
+            *local_output_dir*).
+        s3_bucket_name: S3 bucket name for upload.
+        s3_bucket_path: S3 key prefix for upload.
+        username: SSH username for the remote server.
+        private_key: SSH private key path.
+    """
+    local_file_fullpath = "{}/{}".format(local_output_dir, local_file)
     logging.error(
         "The benchmark returned an error exit status. Fetching remote file {} into {}".format(
             remote_file, local_file_fullpath

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -4,6 +4,7 @@
 #  All rights reserved.
 #
 import logging
+import os
 import sys
 import traceback
 import redis
@@ -329,8 +330,12 @@ def run_remote_command_logic(args, project_name, project_version):
             exit(return_code)
 
     remote_envs = {}
-    dirname = args.db_dirname
+    # remote_db_dir: base directory on the *remote DB server* (e.g. /mnt/flash)
+    remote_db_dir = args.db_dirname
+    # local_tmp_dir: temporary directory on the *local driver* machine for
+    # storing fetched artifacts (logs, zip files, etc.)
     local_tmp_dir = get_tmp_folder_rnd()
+    os.makedirs(local_tmp_dir, exist_ok=True)
     (
         _,
         _,
@@ -536,7 +541,9 @@ def run_remote_command_logic(args, project_name, project_version):
                                 tf_timeout_secs = remote_envs_timeout[remote_id]
                                 client_artifacts = []
                                 client_artifacts_map = {}
-                                temporary_dir = get_tmp_folder_rnd(dirname)
+                                # remote_temporary_dir: random working dir on the
+                                # *remote DB server* (e.g. /mnt/flash/<random>)
+                                remote_temporary_dir = get_tmp_folder_rnd(remote_db_dir)
                                 (
                                     client_public_ip,
                                     server_plaintext_port,
@@ -625,7 +632,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             remote_tmpdir_prune(
                                                 server_public_ip,
                                                 db_ssh_port,
-                                                temporary_dir,
+                                                remote_temporary_dir,
                                                 username,
                                                 private_key,
                                             )
@@ -649,7 +656,8 @@ def run_remote_command_logic(args, project_name, project_version):
                                             client_public_ip,
                                             clusterconfig,
                                             dbdir_folder,
-                                            dirname,
+                                            remote_db_dir,
+                                            local_tmp_dir,
                                             local_module_files,
                                             logname,
                                             required_modules,
@@ -662,7 +670,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             shard_count,
                                             db_ssh_port,
                                             client_ssh_port,
-                                            temporary_dir,
+                                            remote_temporary_dir,
                                             test_name,
                                             testcase_start_time_str,
                                             tf_github_branch,
@@ -711,7 +719,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 setup_details,
                                                 ssh_tunnel,
                                                 full_logfiles,
-                                                temporary_dir,
+                                                remote_temporary_dir,
                                             )
                                             # Update tracker with PIDs after ro_benchmark_set stores them
                                             if setup_details.get(
@@ -748,7 +756,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             server_plaintext_port,
                                             ssh_tunnel,
                                             pids_match,
-                                            temporary_dir,
+                                            remote_temporary_dir,
                                         ) = ro_benchmark_reuse(
                                             artifact_version,
                                             benchmark_type,
@@ -760,7 +768,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             server_plaintext_port,
                                             setup_details,
                                             ssh_tunnel,
-                                            temporary_dir,
+                                            remote_temporary_dir,
                                             benchmark_config,
                                             ignore_keyspace_errors,
                                         )
@@ -1031,7 +1039,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             s3_bucket_name,
                                             s3_bucket_path,
                                             server_public_ip,
-                                            temporary_dir,
+                                            remote_temporary_dir,
                                             args.upload_results_s3,
                                             username,
                                         )
@@ -1198,7 +1206,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                                     s3_bucket_name,
                                                     s3_bucket_path,
                                                     server_public_ip,
-                                                    temporary_dir,
+                                                    remote_temporary_dir,
                                                     args.upload_results_s3,
                                                     username,
                                                 )
@@ -1411,20 +1419,20 @@ def run_remote_command_logic(args, project_name, project_version):
                                         try:
                                             _logname = logname
                                             _full_logfiles = full_logfiles
-                                            # Use the original temporary_dir from setup_details["env"] if available
-                                            # (for reused environments), otherwise use the current temporary_dir
-                                            _temporary_dir = temporary_dir
+                                            # Use the original remote_temporary_dir from setup_details["env"]
+                                            # if available (reused environments), otherwise use the current one
+                                            _remote_temporary_dir = remote_temporary_dir
                                             try:
                                                 if setup_details.get(
                                                     "env"
                                                 ) and setup_details["env"].get(
-                                                    "temporary_dir"
+                                                    "remote_temporary_dir"
                                                 ):
-                                                    _temporary_dir = setup_details[
+                                                    _remote_temporary_dir = setup_details[
                                                         "env"
-                                                    ]["temporary_dir"]
+                                                    ]["remote_temporary_dir"]
                                                     logging.info(
-                                                        f"Using original temporary_dir from reused environment: {_temporary_dir}"
+                                                        f"Using original remote_temporary_dir from reused environment: {_remote_temporary_dir}"
                                                     )
                                             except NameError:
                                                 pass  # setup_details not available
@@ -1440,7 +1448,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 s3_bucket_name,
                                                 s3_bucket_path,
                                                 server_public_ip,
-                                                _temporary_dir,
+                                                _remote_temporary_dir,
                                                 args.upload_results_s3,
                                                 username,
                                             )
@@ -1578,7 +1586,7 @@ def ro_benchmark_reuse(
     server_plaintext_port,
     setup_details,
     ssh_tunnel,
-    temporary_dir,
+    remote_temporary_dir,
     benchmark_config=None,
     ignore_keyspace_errors=False,
 ):
@@ -1596,8 +1604,8 @@ def ro_benchmark_reuse(
     return_code = setup_details["env"]["return_code"]
     server_plaintext_port = setup_details["env"]["server_plaintext_port"]
     ssh_tunnel = setup_details["env"]["ssh_tunnel"]
-    temporary_dir = setup_details["env"]["temporary_dir"]
-    logging.info(f"Reusing temporary_dir from original environment: {temporary_dir}")
+    remote_temporary_dir = setup_details["env"]["remote_temporary_dir"]
+    logging.info(f"Reusing remote_temporary_dir from original environment: {remote_temporary_dir}")
 
     # Verify Redis PIDs are the same (same Redis instance is being reused)
     expected_pids = setup_details["env"].get("redis_pids", [])
@@ -1640,7 +1648,7 @@ def ro_benchmark_reuse(
         server_plaintext_port,
         ssh_tunnel,
         pids_match,
-        temporary_dir,
+        remote_temporary_dir,
     )
 
 
@@ -1654,14 +1662,14 @@ def ro_benchmark_set(
     setup_details,
     ssh_tunnel,
     full_logfiles,
-    temporary_dir,
+    remote_temporary_dir,
 ):
     logging.info(
         "Given the benchmark for this setup is read-only we will prepare to reuse it on the next read-only benchmarks (if any )."
     )
     setup_details["env"] = {}
     setup_details["env"]["full_logfiles"] = full_logfiles
-    setup_details["env"]["temporary_dir"] = temporary_dir
+    setup_details["env"]["remote_temporary_dir"] = remote_temporary_dir
 
     setup_details["env"]["artifact_version"] = artifact_version
     setup_details["env"]["cluster_enabled"] = cluster_enabled
@@ -1684,7 +1692,7 @@ def ro_benchmark_set(
             redis_pids.append(None)
     setup_details["env"]["redis_pids"] = redis_pids
     logging.info(f"Stored Redis PIDs for reuse verification: {redis_pids}")
-    logging.info(f"Stored temporary_dir for reuse: {temporary_dir}")
+    logging.info(f"Stored remote_temporary_dir for reuse: {remote_temporary_dir}")
 
 
 def export_redis_metrics(

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -1428,9 +1428,11 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 ) and setup_details["env"].get(
                                                     "remote_temporary_dir"
                                                 ):
-                                                    _remote_temporary_dir = setup_details[
-                                                        "env"
-                                                    ]["remote_temporary_dir"]
+                                                    _remote_temporary_dir = (
+                                                        setup_details["env"][
+                                                            "remote_temporary_dir"
+                                                        ]
+                                                    )
                                                     logging.info(
                                                         f"Using original remote_temporary_dir from reused environment: {_remote_temporary_dir}"
                                                     )
@@ -1605,7 +1607,9 @@ def ro_benchmark_reuse(
     server_plaintext_port = setup_details["env"]["server_plaintext_port"]
     ssh_tunnel = setup_details["env"]["ssh_tunnel"]
     remote_temporary_dir = setup_details["env"]["remote_temporary_dir"]
-    logging.info(f"Reusing remote_temporary_dir from original environment: {remote_temporary_dir}")
+    logging.info(
+        f"Reusing remote_temporary_dir from original environment: {remote_temporary_dir}"
+    )
 
     # Verify Redis PIDs are the same (same Redis instance is being reused)
     expected_pids = setup_details["env"].get("redis_pids", [])

--- a/redisbench_admin/run_remote/standalone.py
+++ b/redisbench_admin/run_remote/standalone.py
@@ -339,7 +339,7 @@ def validate_remote_host_compatibility(
 
 
 def spin_up_standalone_remote_redis(
-    temporary_dir,
+    remote_temporary_dir,
     server_public_ip,
     username,
     private_key,
@@ -409,7 +409,7 @@ def spin_up_standalone_remote_redis(
         logfile,
         redis_configuration_parameters,
         remote_module_files,
-        temporary_dir,
+        remote_temporary_dir,
         modules_configuration_parameters_map,
         redis_7,
         custom_redis_server_path=remote_redis_server_path,
@@ -438,16 +438,16 @@ def spin_up_standalone_remote_redis(
 
 
 def cp_local_dbdir_to_remote(
-    dbdir_folder, private_key, server_public_ip, temporary_dir, username
+    dbdir_folder, private_key, server_public_ip, remote_temporary_dir, username
 ):
     if dbdir_folder is not None:
         logging.info(
-            "Copying entire content of {} into temporary path: {}".format(
-                dbdir_folder, temporary_dir
+            "Copying entire content of {} into remote temporary path: {}".format(
+                dbdir_folder, remote_temporary_dir
             )
         )
         ssh = SSHSession(server_public_ip, username, key_file=open(private_key, "r"))
-        ssh.put_all(dbdir_folder, temporary_dir)
+        ssh.put_all(dbdir_folder, remote_temporary_dir)
 
 
 def remote_module_files_cp(
@@ -535,7 +535,7 @@ def generate_remote_standalone_redis_cmd(
     logfile,
     redis_configuration_parameters,
     remote_module_files,
-    temporary_dir,
+    remote_temporary_dir,
     modules_configuration_parameters_map,
     enable_redis_7_config_directives=True,
     enable_debug_command="yes",
@@ -555,12 +555,12 @@ def generate_remote_standalone_redis_cmd(
         logging.info(f"Using custom redis.conf: {custom_redis_conf_path}")
     else:
         initial_redis_cmd = "{} --save '' --logfile {} --dir {} --daemonize yes --protected-mode no ".format(
-            redis_server_binary, logfile, temporary_dir
+            redis_server_binary, logfile, remote_temporary_dir
         )
     if enable_redis_7_config_directives:
         extra_str = " --enable-debug-command {} ".format(enable_debug_command)
         initial_redis_cmd = initial_redis_cmd + extra_str
-    full_logfile = "{}/{}".format(temporary_dir, logfile)
+    full_logfile = "{}/{}".format(remote_temporary_dir, logfile)
     if redis_configuration_parameters is not None:
         for (
             configuration_parameter,
@@ -588,7 +588,7 @@ def generate_remote_standalone_redis_cmd(
 
     # Add BigRedis configuration if enabled via environment variable
     if os.getenv("BIGREDIS_ENABLED") is not None:
-        bigredis_path = os.getenv("BIGREDIS_PATH", f"{temporary_dir}/redis.big")
+        bigredis_path = os.getenv("BIGREDIS_PATH", f"{remote_temporary_dir}/redis.big")
         bigredis_use_async = os.getenv("BIGREDIS_USE_ASYNC", "no")
         logging.info(f"BigRedis enabled. Using bigredis-path: {bigredis_path}")
         initial_redis_cmd += " --bigredis-enabled yes"
@@ -635,9 +635,9 @@ def spin_test_standalone_redis(
     logging.info("🚀 Starting spin-test mode...")
 
     try:
-        # Create temporary directory on remote host
-        temporary_dir = "/tmp/redisbench-spin-test"
-        create_dir_commands = [f"mkdir -p {temporary_dir}"]
+        # Create temporary directory on the remote DB host
+        remote_temporary_dir = "/tmp/redisbench-spin-test"
+        create_dir_commands = [f"mkdir -p {remote_temporary_dir}"]
         execute_remote_commands(
             server_public_ip, username, private_key, create_dir_commands, db_ssh_port
         )
@@ -663,7 +663,7 @@ def spin_test_standalone_redis(
                 )
                 return False
 
-            remote_redis_conf_path = f"{temporary_dir}/redis.conf"
+            remote_redis_conf_path = f"{remote_temporary_dir}/redis.conf"
             logging.info("📁 Copying custom redis.conf to remote host...")
 
             copy_result = copy_file_to_remote_setup(
@@ -688,7 +688,7 @@ def spin_test_standalone_redis(
                 )
                 return False
 
-            remote_redis_server_path = f"{temporary_dir}/redis-server"
+            remote_redis_server_path = f"{remote_temporary_dir}/redis-server"
             logging.info("📁 Copying custom redis-server binary to remote host...")
 
             copy_result = copy_file_to_remote_setup(
@@ -723,7 +723,7 @@ def spin_test_standalone_redis(
         # Copy modules if provided
         remote_module_files = None
         if local_module_files:
-            remote_module_file_dir = f"{temporary_dir}/modules"
+            remote_module_file_dir = f"{remote_temporary_dir}/modules"
             create_module_dir_commands = [f"mkdir -p {remote_module_file_dir}"]
             execute_remote_commands(
                 server_public_ip,
@@ -747,7 +747,7 @@ def spin_test_standalone_redis(
         if extra_libs:
             # Ensure module dir exists for extra libs too
             if not local_module_files:
-                remote_module_file_dir = f"{temporary_dir}/modules"
+                remote_module_file_dir = f"{remote_temporary_dir}/modules"
                 create_module_dir_commands = [f"mkdir -p {remote_module_file_dir}"]
                 execute_remote_commands(
                     server_public_ip,
@@ -787,7 +787,7 @@ def spin_test_standalone_redis(
             logfile,
             redis_configuration_parameters,
             remote_module_files,
-            temporary_dir,
+            remote_temporary_dir,
             modules_configuration_parameters_map or {},
             enable_redis_7_config_directives=True,
             enable_debug_command="yes",
@@ -909,7 +909,7 @@ def spin_test_standalone_redis(
         # Cleanup: Stop Redis server
         cleanup_commands = [
             f"redis-cli -p {redis_port} shutdown nosave",
-            f"rm -rf {temporary_dir}",
+            f"rm -rf {remote_temporary_dir}",
         ]
         execute_remote_commands(
             server_public_ip, username, private_key, cleanup_commands, db_ssh_port
@@ -925,7 +925,7 @@ def spin_test_standalone_redis(
         try:
             cleanup_commands = [
                 f"redis-cli -p {redis_port} shutdown nosave",
-                f"rm -rf {temporary_dir}",
+                f"rm -rf {remote_temporary_dir}",
             ]
             execute_remote_commands(
                 server_public_ip, username, private_key, cleanup_commands, db_ssh_port

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -9,7 +9,6 @@ from redisbench_admin.environments.oss_standalone import (
     generate_standalone_redis_server_args,
 )
 
-
 #
 # def test_check_dataset_local_requirements():
 #     url = "https://s3.amazonaws.com/benchmarks.redislabs/redistimeseries/tsbs/datasets/devops/functional/scale-100-redistimeseries_data.rdb"

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -177,7 +177,7 @@ def test_extract_perversion_timeseries_from_results():
         ) as json_file:
             results_dict = json.load(json_file)
 
-            (timeseries_dict, _, _, _) = prepare_timeseries_dict(
+            timeseries_dict, _, _, _ = prepare_timeseries_dict(
                 "1.0.0",
                 benchmark_config,
                 default_metrics,


### PR DESCRIPTION
## Bug Fix

When Redis failed to start on the remote DB server, `redisbench-admin` tried to fetch error logs via SFTP but failed with:

```
ERROR:root:Unable to fetch remote file: [Errno 2] No such file or directory: '/mnt/flash/search-msmarco-6M-documents-load_2026-04-13-17-12-25.log.zip'
```

### Root Cause

`db_error_artifacts()` inside `remote_db_spin()` received `dirname` (= `DB_DIRNAME`, e.g. `/mnt/flash`) — a path on the **remote DB server** — and passed it to `failed_remote_run_artifact_store()` as the **local** destination directory for saving fetched files via SFTP. Since `/mnt/flash` doesn't exist on the driver machine (GitHub Actions runner), the download failed.

### Fix

`db_error_artifacts()` inside `remote_db_spin()` now receives `local_output_dir` (= `local_tmp_dir`, e.g. `/tmp/<random>`), which is a proper local driver path. `os.makedirs()` is also called to ensure this directory exists before any downloads.

## Refactor: Clarify directory naming

The codebase had an ambiguous `dirname` and `temporary_dir` used across three machines (driver, DB server, client server) with no indication of which machine a path belonged to. This PR renames variables to make the intent explicit:

| Old name | New name | Where it lives | Example |
|----------|----------|---------------|---------|
| `dirname` (in `run_remote.py`) | `remote_db_dir` | Remote DB server | `/mnt/flash` |
| `dirname` (in `remote_failures.py`) | `local_output_dir` | Local driver | `/tmp/<random>` |
| `dirname` (in `remote_db.py` `db_error_artifacts`) | `local_output_dir` | Local driver | `/tmp/<random>` |
| `temporary_dir` (everywhere in `run_remote/`) | `remote_temporary_dir` | Remote DB server | `/mnt/flash/<random>` |

### Files changed

- **`remote_failures.py`** — `dirname` → `local_output_dir` in `failed_remote_run_artifact_store()`
- **`remote_db.py`** — `dirname` → `remote_db_dir` + new `local_output_dir` param in `remote_db_spin()`; `temporary_dir` → `remote_temporary_dir` everywhere
- **`run_remote.py`** — `dirname` → `remote_db_dir`; `temporary_dir` → `remote_temporary_dir`; added `os.makedirs(local_tmp_dir)`; updated dict key in `setup_details["env"]`
- **`standalone.py`** — `temporary_dir` → `remote_temporary_dir` in all functions