### PR TITLE
Push benchmark results keyed by architecture (x86 vs arm don't collide)

### DIFF
--- a/redisbench_admin/run/common.py
+++ b/redisbench_admin/run/common.py
@@ -55,6 +55,7 @@ from redisbench_admin.utils.remote import (
     extract_perversion_timeseries_from_results,
     extract_perbranch_timeseries_from_results,
     extract_perhash_timeseries_from_results,
+    ARCH_X86,
 )
 from redisbench_admin.run.asm import execute_asm_commands
 
@@ -399,6 +400,7 @@ def common_exporter_logic(
     running_platform=None,
     datapoints_timestamp=None,
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     per_version_time_series_dict = {}
     per_branch_time_series_dict = {}
@@ -447,6 +449,7 @@ def common_exporter_logic(
             running_platform,
             testcase_metric_context_paths,
             tf_github_sha=tf_github_sha,
+            arch=arch,
         )
     if tf_github_branch is not None and tf_github_branch != "":
         # extract per branch datapoints
@@ -470,6 +473,7 @@ def common_exporter_logic(
             running_platform,
             testcase_metric_context_paths,
             tf_github_sha=tf_github_sha,
+            arch=arch,
         )
     else:
         logging.error(
@@ -496,6 +500,7 @@ def common_exporter_logic(
             build_variant_name,
             running_platform,
             testcase_metric_context_paths,
+            arch=arch,
         )
     return (
         per_version_time_series_dict,

--- a/redisbench_admin/run/redistimeseries.py
+++ b/redisbench_admin/run/redistimeseries.py
@@ -18,6 +18,7 @@ from redisbench_admin.utils.remote import (
     get_overall_dashboard_keynames,
     exporter_create_ts,
     push_data_to_redistimeseries,
+    ARCH_X86,
 )
 from redisbench_admin.utils.utils import get_ts_metric_name
 
@@ -40,6 +41,7 @@ def prepare_timeseries_dict(
     running_platform=None,
     datapoints_timestamp=None,
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     time_series_dict = {}
     # check which metrics to extract
@@ -71,6 +73,7 @@ def prepare_timeseries_dict(
         running_platform,
         datapoints_timestamp,
         tf_github_sha=tf_github_sha,
+        arch=arch,
     )
     time_series_dict.update(per_version_time_series_dict)
     time_series_dict.update(per_branch_time_series_dict)
@@ -250,6 +253,7 @@ def timeseries_test_sucess_flow(
     running_platform=None,
     timeseries_dict=None,
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     testcase_metric_context_paths = []
     version_target_tables = None
@@ -281,6 +285,7 @@ def timeseries_test_sucess_flow(
             running_platform,
             start_time_ms,
             tf_github_sha=tf_github_sha,
+            arch=arch,
         )
     if push_results_redistimeseries:
         logging.info(

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -17,6 +17,8 @@ from redisbench_admin.utils.remote import (
     get_project_ts_tags,
     push_data_to_redistimeseries,
     perform_connectivity_test,
+    detect_target_arch,
+    ARCH_X86,
 )
 from redisbench_admin.utils.redisearch import extract_module_git_sha
 
@@ -648,6 +650,11 @@ def run_local_command_logic(args, project_name, project_version):
                                         )
                                     if not push_github_sha:
                                         push_github_sha = github_sha
+                                push_arch = None
+                                if redis_conns:
+                                    push_arch = detect_target_arch(redis_conns[0])
+                                if not push_arch:
+                                    push_arch = args.architecture or ARCH_X86
                                 (
                                     _,
                                     branch_target_tables,
@@ -671,6 +678,7 @@ def run_local_command_logic(args, project_name, project_version):
                                     tf_triggering_env,
                                     metadata_tags,
                                     tf_github_sha=push_github_sha,
+                                    arch=push_arch,
                                 )
 
                                 if setup_details["env"] is None:

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -76,6 +76,8 @@ from redisbench_admin.utils.remote import (
     push_data_to_redistimeseries,
     fetch_remote_id_from_config,
     perform_connectivity_test,
+    detect_target_arch,
+    ARCH_X86,
 )
 from redisbench_admin.utils.redisearch import extract_module_git_sha
 
@@ -1334,6 +1336,13 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 )
                                             if not push_github_sha:
                                                 push_github_sha = tf_github_sha
+                                        push_arch = None
+                                        if redis_conns:
+                                            push_arch = detect_target_arch(
+                                                redis_conns[0]
+                                            )
+                                        if not push_arch:
+                                            push_arch = args.architecture or ARCH_X86
                                         (
                                             _,
                                             branch_target_tables,
@@ -1357,6 +1366,7 @@ def run_remote_command_logic(args, project_name, project_version):
                                             tf_triggering_env,
                                             metadata_tags,
                                             tf_github_sha=push_github_sha,
+                                            arch=push_arch,
                                         )
                                         if branch_target_tables is not None:
                                             for (

--- a/redisbench_admin/utils/remote.py
+++ b/redisbench_admin/utils/remote.py
@@ -36,6 +36,41 @@ VALID_ARCHS = [ARCH_X86, ARCH_ARM]
 ARCH = os.getenv("ARCH", ARCH_X86)
 
 
+def detect_target_arch(redis_conn):
+    """Detect the architecture of the Redis server behind `redis_conn`.
+
+    Parses the `os` field returned by `INFO server`. A typical value looks
+    like `Linux 6.8.0-1015-aws aarch64` — the last whitespace-separated
+    token is the machine architecture.
+
+    Returns one of VALID_ARCHS (`x86_64` / `aarch64`) on success.
+    Returns None if the server is unreachable, the field is missing, or
+    the arch token is unknown — callers should fall back to a safe default
+    (ARCH_X86) so existing behavior is preserved.
+
+    Never raises.
+    """
+    try:
+        info = redis_conn.info("server")
+    except Exception as err:  # redis.RedisError + connection edge cases
+        logging.debug("INFO server failed while detecting arch: %s", err)
+        return None
+    os_field = info.get("os") if isinstance(info, dict) else None
+    if not os_field:
+        return None
+    tokens = str(os_field).split()
+    if not tokens:
+        return None
+    arch_token = tokens[-1].strip().lower()
+    aliases = {
+        "x86_64": ARCH_X86,
+        "amd64": ARCH_X86,
+        "aarch64": ARCH_ARM,
+        "arm64": ARCH_ARM,
+    }
+    return aliases.get(arch_token)
+
+
 # environment variables
 PERFORMANCE_RTS_PUSH = bool(int(os.getenv("PUSH_RTS", "0")))
 PERFORMANCE_RTS_AUTH = os.getenv("PERFORMANCE_RTS_AUTH", None)
@@ -900,6 +935,7 @@ def extract_perversion_timeseries_from_results(
     running_platform=None,
     testcase_metric_context_paths=[],
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     break_by_key = "version"
     break_by_str = "by.{}".format(break_by_key)
@@ -924,6 +960,7 @@ def extract_perversion_timeseries_from_results(
         running_platform,
         testcase_metric_context_paths,
         tf_github_sha=tf_github_sha,
+        arch=arch,
     )
     return True, branch_time_series_dict, target_tables
 
@@ -946,6 +983,7 @@ def common_timeseries_extraction(
     running_platform=None,
     testcase_metric_context_paths=[],
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     time_series_dict = {}
     target_tables = {}
@@ -981,6 +1019,7 @@ def common_timeseries_extraction(
             time_series_dict,
             use_metric_context_path,
             tf_github_sha=tf_github_sha,
+            arch=arch,
         )
         target_tables[target_table_keyname] = target_table_dict
 
@@ -1010,6 +1049,7 @@ def from_metric_kv_to_timeserie(
     time_series_dict,
     use_metric_context_path,
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     timeserie_tags, ts_name = get_ts_tags_and_name(
         break_by_key,
@@ -1029,6 +1069,7 @@ def from_metric_kv_to_timeserie(
         tf_github_repo,
         tf_triggering_env,
         use_metric_context_path,
+        arch=arch,
         tf_github_sha=tf_github_sha,
     )
     time_series_dict[ts_name] = {
@@ -1214,6 +1255,7 @@ def extract_perbranch_timeseries_from_results(
     running_platform=None,
     testcase_metric_context_paths=[],
     tf_github_sha=None,
+    arch=ARCH_X86,
 ):
     break_by_key = "branch"
     break_by_str = "by.{}".format(break_by_key)
@@ -1235,6 +1277,7 @@ def extract_perbranch_timeseries_from_results(
         running_platform,
         testcase_metric_context_paths,
         tf_github_sha=tf_github_sha,
+        arch=arch,
     )
     return True, branch_time_series_dict, target_tables
 
@@ -1254,6 +1297,7 @@ def extract_perhash_timeseries_from_results(
     build_variant_name=None,
     running_platform=None,
     testcase_metric_context_paths=[],
+    arch=ARCH_X86,
 ):
     break_by_key = "hash"
     break_by_str = "by.{}".format(break_by_key)
@@ -1275,6 +1319,7 @@ def extract_perhash_timeseries_from_results(
         running_platform,
         testcase_metric_context_paths,
         tf_github_sha=tf_github_sha,
+        arch=arch,
     )
     return True, hash_time_series_dict, target_tables
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -415,6 +415,111 @@ def test_prepare_timeseries_dict_without_github_sha_skips_hash_keys():
     assert hash_target_tables == {} or hash_target_tables is None
 
 
+def test_prepare_timeseries_dict_default_arch_x86_unchanged_keys():
+    """Default arch is x86_64 → keys have no arch suffix, labels tag
+    arch=x86_64. This is the pre-existing behavior and must be preserved."""
+    with open("./tests/test_data/common-properties-v0.1.yml", "r") as yml_file:
+        (
+            _,
+            _,
+            default_metrics,
+            exporter_timemetric_path,
+            _,
+            _,
+        ) = process_default_yaml_properties_file(None, None, None, "1.yml", None, yml_file)
+    with open("./tests/test_data/tsbs-devops-ingestion-scale100-4days.yml", "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+    with open(
+        "./tests/test_data/tsbs_load_redistimeseries_result.json", "r"
+    ) as json_file:
+        results_dict = json.load(json_file)
+
+    timeseries_dict, _, _, _, _ = prepare_timeseries_dict(
+        "1.0.0",
+        benchmark_config,
+        default_metrics,
+        "oss-standalone",
+        "oss",
+        exporter_timemetric_path,
+        results_dict,
+        "test_name",
+        "tf_github_branch",
+        "tf_github_org",
+        "tf_github_repo",
+        "tf_triggering_env",
+    )
+    assert not any("arch=" in k for k in timeseries_dict)
+    for _, ts in timeseries_dict.items():
+        assert ts["labels"]["arch"] == "x86_64"
+
+
+def test_prepare_timeseries_dict_with_aarch64_arch_segregates_keys():
+    """ARM benchmark pushed alongside the same benchmark name on x86 must
+    NOT collide: keys carry an arch=aarch64 suffix and labels tag the
+    running arch so Grafana can split them."""
+    with open("./tests/test_data/common-properties-v0.1.yml", "r") as yml_file:
+        (
+            _,
+            _,
+            default_metrics,
+            exporter_timemetric_path,
+            _,
+            _,
+        ) = process_default_yaml_properties_file(None, None, None, "1.yml", None, yml_file)
+    with open("./tests/test_data/tsbs-devops-ingestion-scale100-4days.yml", "r") as yml_file:
+        benchmark_config = yaml.safe_load(yml_file)
+    with open(
+        "./tests/test_data/tsbs_load_redistimeseries_result.json", "r"
+    ) as json_file:
+        results_dict = json.load(json_file)
+
+    timeseries_dict_x86, _, _, _, _ = prepare_timeseries_dict(
+        "1.0.0",
+        benchmark_config,
+        default_metrics,
+        "oss-standalone",
+        "oss",
+        exporter_timemetric_path,
+        results_dict,
+        "test_name",
+        "tf_github_branch",
+        "tf_github_org",
+        "tf_github_repo",
+        "tf_triggering_env",
+        arch="x86_64",
+    )
+    timeseries_dict_arm, _, _, _, _ = prepare_timeseries_dict(
+        "1.0.0",
+        benchmark_config,
+        default_metrics,
+        "oss-standalone",
+        "oss",
+        exporter_timemetric_path,
+        results_dict,
+        "test_name",
+        "tf_github_branch",
+        "tf_github_org",
+        "tf_github_repo",
+        "tf_triggering_env",
+        arch="aarch64",
+    )
+
+    # every ARM key must carry arch=aarch64 suffix; x86 keys must not
+    for k in timeseries_dict_arm:
+        assert k.endswith("arch=aarch64"), k
+    for k in timeseries_dict_x86:
+        assert "arch=" not in k, k
+
+    # ARM ∩ x86 key sets must be disjoint — the whole point of this change
+    assert set(timeseries_dict_x86).isdisjoint(set(timeseries_dict_arm))
+
+    # labels carry the running arch on both sides
+    for _, ts in timeseries_dict_arm.items():
+        assert ts["labels"]["arch"] == "aarch64"
+    for _, ts in timeseries_dict_x86.items():
+        assert ts["labels"]["arch"] == "x86_64"
+
+
 def test_exporter_create_ts():
     import os
     import pytest

--- a/tests/test_target_arch.py
+++ b/tests/test_target_arch.py
@@ -1,0 +1,95 @@
+import os
+
+import pytest
+import redis
+
+from redisbench_admin.utils.remote import (
+    ARCH_ARM,
+    ARCH_X86,
+    detect_target_arch,
+)
+
+
+class _StubConn:
+    def __init__(self, info_reply=None, info_raises=None):
+        self._info_reply = info_reply
+        self._info_raises = info_raises
+
+    def info(self, section=None):
+        if self._info_raises is not None:
+            raise self._info_raises
+        return self._info_reply
+
+
+def test_detect_target_arch_x86_from_linux_info():
+    conn = _StubConn(info_reply={"os": "Linux 6.8.0-1015-aws x86_64"})
+    assert detect_target_arch(conn) == ARCH_X86
+
+
+def test_detect_target_arch_arm_from_linux_info():
+    conn = _StubConn(info_reply={"os": "Linux 6.8.0-1015-aws aarch64"})
+    assert detect_target_arch(conn) == ARCH_ARM
+
+
+def test_detect_target_arch_amd64_alias():
+    conn = _StubConn(info_reply={"os": "Linux 5.15.0 amd64"})
+    assert detect_target_arch(conn) == ARCH_X86
+
+
+def test_detect_target_arch_arm64_alias():
+    conn = _StubConn(info_reply={"os": "Darwin 23.0 arm64"})
+    assert detect_target_arch(conn) == ARCH_ARM
+
+
+def test_detect_target_arch_unknown_returns_none():
+    conn = _StubConn(info_reply={"os": "Linux 5.4 armv7l"})
+    assert detect_target_arch(conn) is None
+
+
+def test_detect_target_arch_missing_os_field_returns_none():
+    conn = _StubConn(info_reply={"redis_version": "7.4.0"})
+    assert detect_target_arch(conn) is None
+
+
+def test_detect_target_arch_empty_os_field_returns_none():
+    conn = _StubConn(info_reply={"os": ""})
+    assert detect_target_arch(conn) is None
+
+
+def test_detect_target_arch_info_connection_error_returns_none():
+    conn = _StubConn(info_raises=redis.ConnectionError("down"))
+    assert detect_target_arch(conn) is None
+
+
+def test_detect_target_arch_info_generic_error_returns_none():
+    """Must swallow any exception — the fallback path should be safe."""
+    conn = _StubConn(info_raises=RuntimeError("unexpected"))
+    assert detect_target_arch(conn) is None
+
+
+def test_detect_target_arch_non_dict_reply_returns_none():
+    conn = _StubConn(info_reply="oops")
+    assert detect_target_arch(conn) is None
+
+
+def test_detect_target_arch_case_insensitive():
+    conn = _StubConn(info_reply={"os": "Linux 6.8.0 AARCH64"})
+    assert detect_target_arch(conn) == ARCH_ARM
+
+
+def test_detect_target_arch_against_live_redis_stack():
+    """End-to-end against the tox-managed redis-stack sidecar. Runs only
+    when RTS_PORT is set (i.e. under `tox -e integration-tests`)."""
+    if "RTS_PORT" not in os.environ:
+        pytest.skip("RTS_PORT environment variable not set")
+    rts_port = os.environ["RTS_PORT"]
+    try:
+        conn = redis.Redis(port=rts_port)
+        conn.ping()
+    except redis.ConnectionError:
+        pytest.skip("Could not connect to redis-stack sidecar on RTS_PORT")
+
+    arch = detect_target_arch(conn)
+    assert arch in (ARCH_X86, ARCH_ARM), (
+        "expected a valid arch from live INFO server, got {}".format(arch)
+    )


### PR DESCRIPTION
## Summary

Before this PR, `run-local` / `run-remote` did **not** thread architecture into the RedisTimeSeries push path: `from_metric_kv_to_timeserie` called `get_ts_tags_and_name` with no `arch` argument, defaulting it to `ARCH_X86`. A benchmark with the same name run on ARM and on Intel therefore produced the **same** TS key with the **same** `arch=x86_64` label — silently overwriting/interleaving data.

This PR:

- Adds `detect_target_arch(redis_conn)` in `utils/remote.py`. Parses the `os` field from `INFO server` (e.g. `Linux 6.8 aarch64`) and returns one of `VALID_ARCHS`. Accepts `amd64`/`arm64` aliases. Never raises — returns `None` on any edge so callers fall through.
- Plumbs `arch` through the entire push pipeline: `timeseries_test_sucess_flow` → `prepare_timeseries_dict` → `common_exporter_logic` → `extract_per{branch,version,hash}_timeseries_from_results` → `common_timeseries_extraction` → `from_metric_kv_to_timeserie` → `get_ts_tags_and_name`.
- `run_local.py` / `run_remote.py` compute `push_arch` at push-time with precedence: **`detect_target_arch(redis_conns[0])` (ground truth) → `args.architecture` (existing CLI flag, env-sourced) → `ARCH_X86`**. Live detection wins because for remote runs the admin host may differ from the benchmark target.

**Behavior preserved for x86**: default arch is unchanged, no arch suffix on keys, existing dashboards keep working. **ARM results now land in distinct keys suffixed with `arch=aarch64`** and carry the correct `arch` label.

## Files touched

- `redisbench_admin/utils/remote.py` — new `detect_target_arch`; `arch` threaded through `from_metric_kv_to_timeserie`, `common_timeseries_extraction`, `extract_per{version,branch,hash}_timeseries_from_results`.
- `redisbench_admin/run/common.py:common_exporter_logic` — accepts and forwards `arch`.
- `redisbench_admin/run/redistimeseries.py` — `prepare_timeseries_dict` and `timeseries_test_sucess_flow` accept and forward `arch`.
- `redisbench_admin/run_local/run_local.py`, `redisbench_admin/run_remote/run_remote.py` — compute `push_arch` and pass it in.
- `tests/test_target_arch.py` — 12 unit tests + 1 live integration.
- `tests/test_remote.py` — 2 new tests asserting x86 vs arm key disjointness and label correctness.

## Test plan

- [x] `tox -e compliance` (black + flake8) — green
- [x] `tox -e integration-tests` (full suite with docker redis-stack sidecar) — **160 passed, 1 skipped (RUN_REMOTE_TESTS-gated), 0 failed**
- [x] Coverage of new code paths verified:
  - 12 unit tests in `test_target_arch.py` cover x86/arm/aliases, case-insensitivity, missing/empty/malformed/unknown `os`, and full exception safety (RedisError / ConnectionError / arbitrary `RuntimeError`).
  - `test_extract_module_git_sha_against_live_redis_stack` (from #520) continues to pass.
  - `test_detect_target_arch_against_live_redis_stack` proves live detection works against the real sidecar.
  - `test_prepare_timeseries_dict_with_aarch64_arch_segregates_keys` asserts `set(x86_keys).isdisjoint(set(arm_keys))`.
- [ ] Smoke-run a live benchmark on an ARM box and confirm new `…arch=aarch64` keys appear in RTS (manual, pre-merge if desired).

## Compatibility notes for dashboards / Grafana

- Existing x86 keys are byte-for-byte unchanged.
- ARM data will start appearing in **new** keys (the `arch=aarch64` suffix). Existing dashboards that filter by the `arch` label will pick them up automatically; dashboards that hardcode key globs may need `arch=*` alternation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)