### PR TITLE
Bumping version from 0.12.19 to 0.12.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.19"
+version = "0.12.20"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"


### PR DESCRIPTION
Patch release including the two feature PRs just merged:

- #520 — push benchmark results by module git_sha (with `ft.debug git_sha` auto-inference)
- #521 — segregate pushed results by target architecture so x86 and arm benchmarks don't collide

Single-file bump of `pyproject.toml`.