### PR TITLE
docs(AGENTS.md): document tox as test runner and admin-merge caveat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,26 @@
 # Release Process
 
 1. Bump the version using `poetry version <patch|minor|major>`
-2. Create a pull request and wait for it to be merged
+2. Create a pull request and wait for it to be merged.
+   - Branch protection on `master` requires an approving review. GitHub
+     forbids approving your own PR, so a version-bump PR authored by the
+     releaser must either be reviewed by someone else or merged with
+     `gh pr merge --admin` (admin override).
 3. Create a new release on GitHub with `gh release create v$(poetry version) --generate-notes`
 4. Wait for GitHub Actions to publish the package to PyPI
+
+# Testing
+
+Use `tox` — the integration suite requires a docker-backed Redis-Stack
+sidecar (exposes `RTS_PORT`). Bare `poetry run pytest` silently skips or
+fails the RTS-dependent tests.
+
+- Full suite: `tox`
+- Compliance (black + flake8): `tox -e compliance`
+- Format in place: `tox -e format`
+- Scoped run: `tox -- tests/test_foo.py -v`
+- Persist the docker RTS container across runs:
+  `tox --docker-dont-stop=rts_datasink -- -vv --log-cli-level=INFO tests/test_foo.py`
 
 # Git Commits
 


### PR DESCRIPTION
Captures two recurring gotchas future agents and maintainers will otherwise keep re-hitting:

- **Testing is `tox`, not bare `pytest`.** The integration suite needs the docker-backed Redis-Stack sidecar (exposes `RTS_PORT`); bare `poetry run pytest` silently skips those tests. Adds common invocations (compliance, format, scoped run, persistent sidecar).
- **Branch protection forces `--admin` on self-authored bump PRs.** Master requires an approving review; GitHub forbids self-approval. A bump PR authored by the releaser needs either a second reviewer or `gh pr merge --admin`.

Paired with #523 (removing the silent `release-drafter` workflow) this finishes cleaning up the session's release-flow friction points.