### PR TITLE
compare: surface arch + deployment + triggering_env in PR comment header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.23"
+version = "0.12.24"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/compare/compare.py
+++ b/redisbench_admin/compare/compare.py
@@ -319,10 +319,36 @@ def compare_command_logic(args, project_name, project_version):
     if total_comparison_points > 0:
         comment_body = "### Automated performance analysis summary\n\n"
         comment_body += "This comment was automatically generated given there is performance data available.\n\n"
+        # Environment header -- surfaces the setup / architecture / platform
+        # the comparison was run against so a PR reviewer doesn't have to
+        # cross-reference the CI run to know what the numbers mean. When
+        # baseline and comparison used the same value, collapse to one line;
+        # when they diverge (e.g. x86 vs ARM cross-arch compare, or
+        # oss-standalone vs oss-standalone-threads-6 cross-topology), show
+        # both sides explicitly.
+        env_lines = []
         if running_platform is not None:
-            comment_body += "Using platform named: {} to do the comparison.\n\n".format(
-                running_platform
-            )
+            env_lines.append(f"- Running platform: `{running_platform}`")
+        if tf_triggering_env:
+            env_lines.append(f"- Triggering env: `{tf_triggering_env}`")
+        if baseline_architecture or comparison_architecture:
+            if baseline_architecture == comparison_architecture:
+                env_lines.append(f"- Architecture: `{baseline_architecture}`")
+            else:
+                env_lines.append(
+                    f"- Architecture (baseline / comparison): "
+                    f"`{baseline_architecture}` / `{comparison_architecture}`"
+                )
+        if baseline_deployment_name or comparison_deployment_name:
+            if baseline_deployment_name == comparison_deployment_name:
+                env_lines.append(f"- Deployment: `{baseline_deployment_name}`")
+            else:
+                env_lines.append(
+                    f"- Deployment (baseline / comparison): "
+                    f"`{baseline_deployment_name}` / `{comparison_deployment_name}`"
+                )
+        if env_lines:
+            comment_body += "**Environment:**\n" + "\n".join(env_lines) + "\n\n"
         comparison_summary = "In summary:\n"
         if total_stable > 0:
             comparison_summary += (


### PR DESCRIPTION
## Summary

The auto-generated PR comment from \`redisbench-admin compare\` was vague about the environment the numbers came from. Only \`running_platform\` was mentioned, as prose, buried in the opening paragraph. Reviewers couldn't tell at-a-glance whether the comparison was x86 vs ARM, which deployment (\`oss-standalone\` vs \`oss-standalone-threads-6\` vs \`oss-cluster-*\`) the numbers came from, or which triggering_env was used to filter RTS samples.

Replaces that line with a structured **Environment** block:

\`\`\`
### Automated performance analysis summary

This comment was automatically generated given there is performance data available.

**Environment:**
- Running platform: \`x86-aws-m7i.metal-24xl\`
- Triggering env: \`github-actions\`
- Architecture (baseline / comparison): \`x86_64\` / \`aarch64\`
- Deployment: \`oss-standalone\`

In summary:
- Detected a total of N stable tests between versions.
...
\`\`\`

When baseline and comparison share a value, collapse to one line; when they diverge (cross-arch compare, cross-topology compare) show both sides explicitly — those are the cases where the distinction actually matters.

## Changes

\`redisbench_admin/compare/compare.py\` only — builds \`env_lines\` from the already-parsed args (\`running_platform\`, \`tf_triggering_env\`, \`baseline_architecture\` / \`comparison_architecture\`, \`baseline_deployment_name\` / \`comparison_deployment_name\`) and drops them into a markdown bullet list at the top of the comment. No new CLI surface; nothing to configure.

## Test plan

- [x] \`black --check redisbench_admin\` passes
- [x] \`poetry run python -c \"from redisbench_admin.compare.compare import compare_command_logic\"\` imports cleanly
- [x] \`pytest tests/test_compare.py\` — 3 skipped (they need live RTS), no failures
- [ ] End-to-end: next PR comment produced by a benchmark-flow.yml CI run shows the new Environment header. Will verify on RediSearch/RediSearch#9257's next benchmark CI run after the submodule bump.

## Motivation

Originated from reviewer feedback that existing compare comments (e.g. https://github.com/RediSearch/RediSearch/pull/XYZ) didn't make the setup context obvious — especially important now that we're starting to produce x86-vs-ARM comparisons where both sides must be explicit in the header for the result table to make sense.