### PR TITLE
Bumping version from 0.12.21 to 0.12.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.21"
+version = "0.12.22"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"


### PR DESCRIPTION
Patch release including the per-test parca-agent label injection merged on top of 0.12.21:

- #525 — per-test parca-agent `metadata-external-labels` injection (`test_name`, `git_hash`, `tested_commands`, `arch`, `topology`, ...)
- `run-remote`: env var override for testing-infrastructure source (`TESTING_INFRASTRUCTURE_REPO` / `_BRANCH`)
- docs(AGENTS.md): tox runner + admin-merge caveat (#524)

Single-file bump of `pyproject.toml`. Follow-up: once this is merged, cut a GitHub release tag `v0.12.22` to fire `publish-pypi.yml`.