### PR TITLE
parca_agent_labels: snap restart after label set/clear + bump 0.12.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.22"
+version = "0.12.23"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run_remote/parca_agent_labels.py
+++ b/redisbench_admin/run_remote/parca_agent_labels.py
@@ -83,10 +83,41 @@ def _format_labels(labels):
     return ";".join(parts)
 
 
-def set_parca_agent_labels(ip, port, user, pk, labels):
-    """Push metadata-external-labels=... to the parca-agent snap.
+def _restart_parca_agent(ip, port, user, pk):
+    """Restart the parca-agent snap service so new snap config takes effect.
 
-    Returns True on successful set. Logs but does not raise on failure.
+    The parca-agent snap's `parca-agent-wrapper` reads snap config via
+    `snapctl get` *once* at service start and bakes the values into the
+    `--metadata-external-labels=...` command-line flag. Runtime `snap set`
+    updates the stored config but leaves the running process untouched, so
+    samples continue to ship with whatever labels were baked in at boot
+    (typically empty). A service restart is therefore required after every
+    `snap set metadata-external-labels=...`. Sampling pauses for a few
+    seconds while the eBPF profiler re-attaches -- acceptable for
+    multi-minute benchmark runs.
+    """
+    cmd = "sudo snap restart parca-agent.parca-agent-svc"
+    res = _ssh(ip, user, pk, port, [cmd], timeout=60)
+    if not res:
+        return False
+    exit_code, _, stderr = res[0]
+    if exit_code != 0:
+        logging.warning(
+            "snap restart parca-agent.parca-agent-svc failed (exit=%d) on %s: %s",
+            exit_code,
+            ip,
+            stderr,
+        )
+        return False
+    return True
+
+
+def set_parca_agent_labels(ip, port, user, pk, labels):
+    """Push metadata-external-labels=... to the parca-agent snap and restart
+    the service so the new labels take effect on live samples.
+
+    Returns True on successful set + restart. Logs but does not raise on
+    failure.
     """
     blob = _format_labels(labels)
     if not blob:
@@ -105,22 +136,26 @@ def set_parca_agent_labels(ip, port, user, pk, labels):
             stderr,
         )
         return False
+    if not _restart_parca_agent(ip, port, user, pk):
+        # set succeeded but restart didn't -- labels are in snap config but
+        # won't reach live samples until the next natural restart
+        return False
     preview = blob if len(blob) < 300 else (blob[:297] + "...")
     logging.info("parca-agent labels set on %s: %s", ip, preview)
     return True
 
 
 def clear_parca_agent_labels(ip, port, user, pk):
-    """Clear metadata-external-labels on the snap.
+    """Clear metadata-external-labels on the snap and restart the service.
 
     Call between tests (or on teardown) so a crash mid-run doesn't leave
     stale labels attached to samples from the next test.
     """
     cmd = 'sudo snap set parca-agent metadata-external-labels=""'
     res = _ssh(ip, user, pk, port, [cmd])
-    if not res:
+    if not res or res[0][0] != 0:
         return False
-    return res[0][0] == 0
+    return _restart_parca_agent(ip, port, user, pk)
 
 
 def build_labels(


### PR DESCRIPTION
## Root cause

The parca-agent snap's \`parca-agent-wrapper\` reads \`metadata-external-labels\` via \`snapctl get\` **once** at service start and bakes it into the \`--metadata-external-labels=...\` command-line flag. Runtime \`snap set metadata-external-labels=...\` only updates the stored snap config — the already-running process keeps whatever value it was started with (typically empty, from cloud-init).

## Evidence

RediSearch PR #9257 run [24858607091](https://github.com/RediSearch/RediSearch/actions/runs/24858607091) — redisbench-admin 0.12.22 — logs show labels being injected correctly:

\`\`\`
parca-agent labels set on 18.116.63.186:
  platform=oss-standalone;topology=oss-standalone;arch=x86_64;
  coordinator_version=0.12.22;git_hash=64112a96...;
  test_name=vecsim-arxiv-titles-384-angular-filters-...;
  client_tool=memtier_benchmark;tested_groups=vecsim
\`\`\`

But Polar Signals receives those samples with **no external labels**. SSH to the DB confirmed \`ps auxf\` shows the live parca-agent process still has \`--metadata-external-labels=\` (empty) baked in from the cloud-init snap boot.

## Fix

After every \`snap set metadata-external-labels=...\`, run \`snap restart parca-agent.parca-agent-svc\`. Sampling pauses for a few seconds while the eBPF profiler re-attaches — acceptable for multi-minute benchmarks.

## Ship

Also bumps to \`0.12.23\` so the fix lands on PyPI and the next CI run pulls it automatically.