### PR TITLE
compare: multi-arch sections + cross-arch delta + bump 0.12.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.24"
+version = "0.12.25"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/compare/args.py
+++ b/redisbench_admin/compare/args.py
@@ -75,6 +75,32 @@ def create_compare_arguments(parser):
         help=f"Architecture to filter comparison time-series. One of {VALID_ARCHS}.",
     )
     parser.add_argument(
+        "--architectures",
+        type=str,
+        required=False,
+        default=None,
+        help=(
+            "Comma-separated list of architectures to render as sections in "
+            "the PR comment (e.g. 'x86_64,aarch64'). When set, overrides "
+            "--baseline_architecture / --comparison_architecture: each arch "
+            "produces its own branch-over-branch section and, when >=2 archs "
+            "return data, a cross-arch delta section is appended. When an "
+            "arch has no data, a warning block is emitted in its place and "
+            "the cross-arch section is skipped. "
+            f"Valid values: {VALID_ARCHS}."
+        ),
+    )
+    parser.add_argument(
+        "--no-cross-arch",
+        required=False,
+        default=False,
+        action="store_true",
+        help=(
+            "When --architectures has >=2 values, skip the cross-arch delta "
+            "section. Ignored in single-arch / legacy mode."
+        ),
+    )
+    parser.add_argument(
         "--last_n",
         type=int,
         default=-1,

--- a/redisbench_admin/compare/compare.py
+++ b/redisbench_admin/compare/compare.py
@@ -32,6 +32,271 @@ def get_project_compare_zsets(triggering_env, org, repo):
     )
 
 
+def _build_env_lines(
+    running_platform,
+    tf_triggering_env,
+    baseline_architecture,
+    comparison_architecture,
+    baseline_deployment_name,
+    comparison_deployment_name,
+    include_arch=True,
+    include_deployment=True,
+):
+    """Build the bullet list under **Environment:** in the PR comment.
+
+    Legacy single-arch mode passes include_arch=True and include_deployment=True
+    -- the arch/deployment rows stay in the single section's env block.
+    Multi-arch mode passes False for both because each architecture is its own
+    H2 section (arch moves into the section title; deployment goes inline as a
+    per-section `**Deployment:**` line since it may differ across sections).
+    """
+    env_lines = []
+    if running_platform is not None:
+        env_lines.append(f"- Running platform: `{running_platform}`")
+    if tf_triggering_env:
+        env_lines.append(f"- Triggering env: `{tf_triggering_env}`")
+    if include_arch and (baseline_architecture or comparison_architecture):
+        if baseline_architecture == comparison_architecture:
+            env_lines.append(f"- Architecture: `{baseline_architecture}`")
+        else:
+            env_lines.append(
+                f"- Architecture (baseline / comparison): "
+                f"`{baseline_architecture}` / `{comparison_architecture}`"
+            )
+    if include_deployment and (baseline_deployment_name or comparison_deployment_name):
+        if baseline_deployment_name == comparison_deployment_name:
+            env_lines.append(f"- Deployment: `{baseline_deployment_name}`")
+        else:
+            env_lines.append(
+                f"- Deployment (baseline / comparison): "
+                f"`{baseline_deployment_name}` / `{comparison_deployment_name}`"
+            )
+    return env_lines
+
+
+def _render_section(
+    rts,
+    tf_github_org,
+    tf_github_repo,
+    tf_triggering_env,
+    metric_name,
+    baseline_branch,
+    comparison_branch,
+    baseline_tag,
+    comparison_tag,
+    baseline_deployment_name,
+    comparison_deployment_name,
+    print_improvements_only,
+    print_regressions_only,
+    skip_unstable,
+    regressions_percent_lower_limit,
+    regressions_percent_lower_limit_arg,
+    simplify_table,
+    test,
+    testname_regex,
+    verbose,
+    last_n_baseline,
+    last_n_comparison,
+    metric_mode,
+    from_date,
+    from_ts_ms,
+    to_date,
+    to_ts_ms,
+    use_metric_context_path,
+    running_platform,
+    baseline_architecture,
+    comparison_architecture,
+    first_n_baseline,
+    first_n_comparison,
+    grafana_link_base,
+):
+    """Run compute_regression_table for one (baseline_arch, comparison_arch,
+    baseline_branch, comparison_branch) tuple and render its markdown body.
+
+    Returns a 5-tuple:
+      (section_md, totals, had_data, detected_regressions, comparison_summary)
+
+    `section_md` is only the per-section content (summary + optional grafana
+    link + regression table). The H2 title, the top-level preamble
+    ("### Automated performance analysis summary") and the shared Environment
+    block are the caller's responsibility, because they're shared across
+    architectures in the multi-arch comment.
+    """
+    (
+        detected_regressions,
+        table_output,
+        total_improvements,
+        total_regressions,
+        total_stable,
+        total_unstable,
+        total_comparison_points,
+        total_unstable_baseline,
+        total_unstable_comparison,
+        total_latency_confirmed_regressions,
+        latency_confirmed_regression_details,
+    ) = compute_regression_table(
+        rts,
+        tf_github_org,
+        tf_github_repo,
+        tf_triggering_env,
+        metric_name,
+        comparison_branch,
+        baseline_branch,
+        baseline_tag,
+        comparison_tag,
+        baseline_deployment_name,
+        comparison_deployment_name,
+        print_improvements_only,
+        print_regressions_only,
+        skip_unstable,
+        regressions_percent_lower_limit,
+        simplify_table,
+        test,
+        testname_regex,
+        verbose,
+        last_n_baseline,
+        last_n_comparison,
+        metric_mode,
+        from_date,
+        from_ts_ms,
+        to_date,
+        to_ts_ms,
+        use_metric_context_path,
+        running_platform,
+        baseline_architecture,
+        comparison_architecture,
+        first_n_baseline,
+        first_n_comparison,
+        grafana_link_base,
+    )
+    totals = {
+        "total_improvements": total_improvements,
+        "total_regressions": total_regressions,
+        "total_stable": total_stable,
+        "total_unstable": total_unstable,
+        "total_comparison_points": total_comparison_points,
+        "total_unstable_baseline": total_unstable_baseline,
+        "total_unstable_comparison": total_unstable_comparison,
+        "total_latency_confirmed_regressions": total_latency_confirmed_regressions,
+    }
+    had_data = total_comparison_points > 0
+    if not had_data:
+        return "", totals, False, detected_regressions, ""
+
+    comparison_summary = "In summary:\n"
+    if total_stable > 0:
+        comparison_summary += (
+            f"- Detected a total of {total_stable} stable tests between versions.\n"
+        )
+
+    if total_unstable > 0:
+        unstable_details = []
+        if total_unstable_baseline > 0:
+            unstable_details.append(f"{total_unstable_baseline} baseline")
+        if total_unstable_comparison > 0:
+            unstable_details.append(f"{total_unstable_comparison} comparison")
+
+        unstable_breakdown = (
+            " (" + ", ".join(unstable_details) + ")" if unstable_details else ""
+        )
+        comparison_summary += (
+            "- Detected a total of {} highly unstable benchmarks{}.\n".format(
+                total_unstable, unstable_breakdown
+            )
+        )
+
+        # Add latency confirmation summary if applicable
+        if total_latency_confirmed_regressions > 0:
+            comparison_summary += "- Latency analysis confirmed regressions in {} of the unstable tests:\n".format(
+                total_latency_confirmed_regressions
+            )
+
+            # Add detailed breakdown as bullet points with test links
+            if latency_confirmed_regression_details:
+                for detail in latency_confirmed_regression_details:
+                    test_name = detail["test_name"]
+                    commands_info = []
+                    for cmd_detail in detail["commands"]:
+                        commands_info.append(
+                            f"{cmd_detail['command']} +{cmd_detail['change_percent']:.1f}%"
+                        )
+
+                    if commands_info:
+                        # Create test link if grafana_link_base is available
+                        test_display_name = test_name
+                        if grafana_link_base is not None:
+                            grafana_test_link = (
+                                f"{grafana_link_base}?var-test_case={test_name}"
+                            )
+                            if tf_github_org is not None:
+                                grafana_test_link += f"&var-github_org={tf_github_org}"
+                            if tf_github_repo is not None:
+                                grafana_test_link += (
+                                    f"&var-github_repo={tf_github_repo}"
+                                )
+                            if baseline_branch is not None:
+                                grafana_test_link += f"&var-branch={baseline_branch}"
+                            if comparison_branch is not None:
+                                grafana_test_link += f"&var-branch={comparison_branch}"
+                            grafana_test_link += "&from=now-30d&to=now"
+                            test_display_name = f"[{test_name}]({grafana_test_link})"
+
+                        # Add confidence indicator if available
+                        confidence_indicator = ""
+                        if "high_confidence" in detail:
+                            confidence_indicator = (
+                                " 🔴" if detail["high_confidence"] else " ⚠️"
+                            )
+
+                        comparison_summary += f"  - {test_display_name}: {', '.join(commands_info)}{confidence_indicator}\n"
+    if total_improvements > 0:
+        comparison_summary += f"- Detected a total of {total_improvements} improvements above the improvement water line.\n"
+    if total_regressions > 0:
+        comparison_summary += f"- Detected a total of {total_regressions} regressions bellow the regression water line {regressions_percent_lower_limit_arg}%.\n"
+    comparison_summary += "\n"
+
+    section_md = comparison_summary
+    section_md += "\n"
+    if grafana_link_base is not None:
+        grafana_link = "{}/".format(grafana_link_base)
+        params = []
+        if tf_github_org is not None:
+            params.append(f"var-github_org={tf_github_org}")
+        if tf_github_repo is not None:
+            params.append(f"var-github_repo={tf_github_repo}")
+        if baseline_tag is not None and comparison_tag is not None:
+            params.append(f"var-version={baseline_tag}")
+            params.append(f"var-version={comparison_tag}")
+        if baseline_branch is not None and comparison_branch is not None:
+            params.append(f"var-branch={baseline_branch}")
+            params.append(f"var-branch={comparison_branch}")
+        if params:
+            grafana_link += "?" + "&".join(params)
+        section_md += (
+            "You can check a comparison in detail via the [grafana link]({})".format(
+                grafana_link
+            )
+        )
+    section_md += "\n\n##" + table_output
+    return section_md, totals, True, detected_regressions, comparison_summary
+
+
+def _missing_arch_warning(arch, branch):
+    """Render the warning block shown when an arch has no RTS data on the PR.
+
+    Modules without ARM CI runners will hit this path for `aarch64`; rather
+    than emit an empty table (which reads as 'no regressions', falsely
+    reassuring) or silently drop the section, tell the reviewer exactly
+    what's going on.
+    """
+    return (
+        f"> ⚠️ No `{arch}` benchmark data found on branch `{branch}`. "
+        f"This module may not have ARM CI runners yet; consider adding one "
+        f"or removing `{arch}` from the `--architectures` list. "
+        f"Cross-arch delta skipped.\n\n"
+    )
+
+
 def compare_command_logic(args, project_name, project_version):
     logging.info(
         "Using: {project_name} {project_version}".format(
@@ -268,192 +533,264 @@ def compare_command_logic(args, project_name, project_version):
             )
         )
 
-    (
-        detected_regressions,
-        table_output,
-        total_improvements,
-        total_regressions,
-        total_stable,
-        total_unstable,
-        total_comparison_points,
-        total_unstable_baseline,
-        total_unstable_comparison,
-        total_latency_confirmed_regressions,
-        latency_confirmed_regression_details,
-    ) = compute_regression_table(
-        rts,
-        tf_github_org,
-        tf_github_repo,
-        tf_triggering_env,
-        metric_name,
-        comparison_branch,
-        baseline_branch,
-        baseline_tag,
-        comparison_tag,
-        baseline_deployment_name,
-        comparison_deployment_name,
-        print_improvements_only,
-        print_regressions_only,
-        skip_unstable,
-        regressions_percent_lower_limit,
-        simplify_table,
-        test,
-        testname_regex,
-        verbose,
-        last_n_baseline,
-        last_n_comparison,
-        metric_mode,
-        from_date,
-        from_ts_ms,
-        to_date,
-        to_ts_ms,
-        use_metric_context_path,
-        running_platform,
-        baseline_architecture,
-        comparison_architecture,
-        first_n_baseline,
-        first_n_comparison,
-        grafana_link_base,
-    )
+    # ------------------------------------------------------------------
+    # Dispatch on --architectures: multi-arch body with per-arch sections
+    # + optional cross-arch delta, or the single-arch legacy body.
+    # ------------------------------------------------------------------
+    multi_archs = []
+    if getattr(args, "architectures", None):
+        multi_archs = [a.strip() for a in args.architectures.split(",") if a.strip()]
+
     comment_body = ""
-    if total_comparison_points > 0:
-        comment_body = "### Automated performance analysis summary\n\n"
-        comment_body += "This comment was automatically generated given there is performance data available.\n\n"
-        # Environment header -- surfaces the setup / architecture / platform
-        # the comparison was run against so a PR reviewer doesn't have to
-        # cross-reference the CI run to know what the numbers mean. When
-        # baseline and comparison used the same value, collapse to one line;
-        # when they diverge (e.g. x86 vs ARM cross-arch compare, or
-        # oss-standalone vs oss-standalone-threads-6 cross-topology), show
-        # both sides explicitly.
-        env_lines = []
-        if running_platform is not None:
-            env_lines.append(f"- Running platform: `{running_platform}`")
-        if tf_triggering_env:
-            env_lines.append(f"- Triggering env: `{tf_triggering_env}`")
-        if baseline_architecture or comparison_architecture:
-            if baseline_architecture == comparison_architecture:
-                env_lines.append(f"- Architecture: `{baseline_architecture}`")
-            else:
-                env_lines.append(
-                    f"- Architecture (baseline / comparison): "
-                    f"`{baseline_architecture}` / `{comparison_architecture}`"
+    aggregated_detected_regressions = []
+    aggregated_totals = {
+        "total_improvements": 0,
+        "total_regressions": 0,
+        "total_stable": 0,
+        "total_unstable": 0,
+        "total_comparison_points": 0,
+        "total_unstable_baseline": 0,
+        "total_unstable_comparison": 0,
+        "total_latency_confirmed_regressions": 0,
+    }
+    comparison_summary = ""
+
+    def _accumulate(totals, detected_regressions_local):
+        for k in aggregated_totals:
+            aggregated_totals[k] += totals.get(k, 0)
+        aggregated_detected_regressions.extend(detected_regressions_local)
+
+    if multi_archs:
+        # Multi-arch path: one top-level preamble + env block, then a H2
+        # section per arch (branch-over-branch), then an optional cross-arch
+        # delta section on the comparison branch.
+        logging.info(
+            "Rendering multi-arch comment body for architectures: %s",
+            multi_archs,
+        )
+        per_arch_results = []
+        for arch in multi_archs:
+            section_md, totals, had_data, local_regressions, local_summary = (
+                _render_section(
+                    rts,
+                    tf_github_org,
+                    tf_github_repo,
+                    tf_triggering_env,
+                    metric_name,
+                    baseline_branch,
+                    comparison_branch,
+                    baseline_tag,
+                    comparison_tag,
+                    baseline_deployment_name,
+                    comparison_deployment_name,
+                    print_improvements_only,
+                    print_regressions_only,
+                    skip_unstable,
+                    regressions_percent_lower_limit,
+                    args.regressions_percent_lower_limit,
+                    simplify_table,
+                    test,
+                    testname_regex,
+                    verbose,
+                    last_n_baseline,
+                    last_n_comparison,
+                    metric_mode,
+                    from_date,
+                    from_ts_ms,
+                    to_date,
+                    to_ts_ms,
+                    use_metric_context_path,
+                    running_platform,
+                    arch,
+                    arch,
+                    first_n_baseline,
+                    first_n_comparison,
+                    grafana_link_base,
                 )
-        if baseline_deployment_name or comparison_deployment_name:
-            if baseline_deployment_name == comparison_deployment_name:
-                env_lines.append(f"- Deployment: `{baseline_deployment_name}`")
-            else:
-                env_lines.append(
-                    f"- Deployment (baseline / comparison): "
-                    f"`{baseline_deployment_name}` / `{comparison_deployment_name}`"
-                )
-        if env_lines:
-            comment_body += "**Environment:**\n" + "\n".join(env_lines) + "\n\n"
-        comparison_summary = "In summary:\n"
-        if total_stable > 0:
-            comparison_summary += (
-                f"- Detected a total of {total_stable} stable tests between versions.\n"
             )
-
-        if total_unstable > 0:
-            unstable_details = []
-            if total_unstable_baseline > 0:
-                unstable_details.append(f"{total_unstable_baseline} baseline")
-            if total_unstable_comparison > 0:
-                unstable_details.append(f"{total_unstable_comparison} comparison")
-
-            unstable_breakdown = (
-                " (" + ", ".join(unstable_details) + ")" if unstable_details else ""
+            per_arch_results.append(
+                (arch, section_md, totals, had_data, local_regressions, local_summary)
             )
-            comparison_summary += (
-                "- Detected a total of {} highly unstable benchmarks{}.\n".format(
-                    total_unstable, unstable_breakdown
-                )
+            if had_data:
+                _accumulate(totals, local_regressions)
+
+        # Build the top-level preamble only if at least one arch produced
+        # data; otherwise fall through to the no-data error branch below.
+        any_had_data = any(r[3] for r in per_arch_results)
+        if any_had_data:
+            comment_body = "### Automated performance analysis summary\n\n"
+            comment_body += (
+                "This comment was automatically generated given there is "
+                "performance data available.\n\n"
             )
+            # Arch-per-section, so arch is excluded from the shared env
+            # block. Deployment is also moved per-section (may vary between
+            # branch-over-branch and cross-arch sections in the future).
+            env_lines = _build_env_lines(
+                running_platform,
+                tf_triggering_env,
+                None,
+                None,
+                None,
+                None,
+                include_arch=False,
+                include_deployment=False,
+            )
+            if env_lines:
+                comment_body += "**Environment:**\n" + "\n".join(env_lines) + "\n\n"
 
-            # Add latency confirmation summary if applicable
-            if total_latency_confirmed_regressions > 0:
-                comparison_summary += "- Latency analysis confirmed regressions in {} of the unstable tests:\n".format(
-                    total_latency_confirmed_regressions
-                )
-
-                # Add detailed breakdown as bullet points with test links
-                if latency_confirmed_regression_details:
-                    for detail in latency_confirmed_regression_details:
-                        test_name = detail["test_name"]
-                        commands_info = []
-                        for cmd_detail in detail["commands"]:
-                            commands_info.append(
-                                f"{cmd_detail['command']} +{cmd_detail['change_percent']:.1f}%"
+            for arch, section_md, _, had_data, _, _ in per_arch_results:
+                comment_body += f"## Architecture: `{arch}` — branch-over-branch\n\n"
+                if had_data:
+                    if baseline_deployment_name or comparison_deployment_name:
+                        if baseline_deployment_name == comparison_deployment_name:
+                            comment_body += (
+                                f"**Deployment:** `{baseline_deployment_name}`\n\n"
                             )
+                        else:
+                            comment_body += (
+                                f"**Deployment (baseline / comparison):** "
+                                f"`{baseline_deployment_name}` / "
+                                f"`{comparison_deployment_name}`\n\n"
+                            )
+                    comment_body += section_md + "\n\n"
+                else:
+                    comment_body += _missing_arch_warning(arch, comparison_branch)
 
-                        if commands_info:
-                            # Create test link if grafana_link_base is available
-                            test_display_name = test_name
-                            if grafana_link_base is not None:
-                                grafana_test_link = (
-                                    f"{grafana_link_base}?var-test_case={test_name}"
-                                )
-                                if tf_github_org is not None:
-                                    grafana_test_link += (
-                                        f"&var-github_org={tf_github_org}"
-                                    )
-                                if tf_github_repo is not None:
-                                    grafana_test_link += (
-                                        f"&var-github_repo={tf_github_repo}"
-                                    )
-                                if baseline_branch is not None:
-                                    grafana_test_link += (
-                                        f"&var-branch={baseline_branch}"
-                                    )
-                                if comparison_branch is not None:
-                                    grafana_test_link += (
-                                        f"&var-branch={comparison_branch}"
-                                    )
-                                grafana_test_link += "&from=now-30d&to=now"
-                                test_display_name = (
-                                    f"[{test_name}]({grafana_test_link})"
-                                )
-
-                            # Add confidence indicator if available
-                            confidence_indicator = ""
-                            if "high_confidence" in detail:
-                                confidence_indicator = (
-                                    " 🔴" if detail["high_confidence"] else " ⚠️"
-                                )
-
-                            comparison_summary += f"  - {test_display_name}: {', '.join(commands_info)}{confidence_indicator}\n"
-        if total_improvements > 0:
-            comparison_summary += f"- Detected a total of {total_improvements} improvements above the improvement water line.\n"
-        if total_regressions > 0:
-            comparison_summary += f"- Detected a total of {total_regressions} regressions bellow the regression water line {args.regressions_percent_lower_limit}%.\n"
-        comparison_summary += "\n"
-
-        comment_body += comparison_summary
-        comment_body += "\n"
-
-        if grafana_link_base is not None:
-            grafana_link = "{}/".format(grafana_link_base)
-            params = []
-            if tf_github_org is not None:
-                params.append(f"var-github_org={tf_github_org}")
-            if tf_github_repo is not None:
-                params.append(f"var-github_repo={tf_github_repo}")
-            if baseline_tag is not None and comparison_tag is not None:
-                params.append(f"var-version={baseline_tag}")
-                params.append(f"var-version={comparison_tag}")
-            if baseline_branch is not None and comparison_branch is not None:
-                params.append(f"var-branch={baseline_branch}")
-                params.append(f"var-branch={comparison_branch}")
-            if params:
-                grafana_link += "?" + "&".join(params)
-            comment_body += "You can check a comparison in detail via the [grafana link]({})".format(
-                grafana_link
+            # Cross-arch delta section: both sides on the comparison branch,
+            # architectures differ. Rendered only when we have >=2 archs
+            # with data AND the user didn't opt out via --no-cross-arch.
+            archs_with_data = [r[0] for r in per_arch_results if r[3]]
+            if len(archs_with_data) >= 2 and not getattr(args, "no_cross_arch", False):
+                xa_baseline, xa_comparison = archs_with_data[0], archs_with_data[1]
+                (
+                    xa_section_md,
+                    _,
+                    xa_had_data,
+                    _,
+                    _,
+                ) = _render_section(
+                    rts,
+                    tf_github_org,
+                    tf_github_repo,
+                    tf_triggering_env,
+                    metric_name,
+                    comparison_branch,
+                    comparison_branch,
+                    baseline_tag,
+                    comparison_tag,
+                    baseline_deployment_name,
+                    comparison_deployment_name,
+                    print_improvements_only,
+                    print_regressions_only,
+                    skip_unstable,
+                    regressions_percent_lower_limit,
+                    args.regressions_percent_lower_limit,
+                    simplify_table,
+                    test,
+                    testname_regex,
+                    verbose,
+                    last_n_baseline,
+                    last_n_comparison,
+                    metric_mode,
+                    from_date,
+                    from_ts_ms,
+                    to_date,
+                    to_ts_ms,
+                    use_metric_context_path,
+                    running_platform,
+                    xa_baseline,
+                    xa_comparison,
+                    first_n_baseline,
+                    first_n_comparison,
+                    grafana_link_base,
+                )
+                if xa_had_data:
+                    comment_body += (
+                        f"## Cross-arch delta on `{comparison_branch}` "
+                        f"(`{xa_baseline}` → `{xa_comparison}`)\n\n"
+                    )
+                    comment_body += (
+                        f"> Same commit (`{comparison_branch}`) compared across "
+                        f"architectures. Positive deltas = `{xa_comparison}` "
+                        f"outperforms `{xa_baseline}`.\n\n"
+                    )
+                    comment_body += xa_section_md + "\n\n"
+                    # Display-only; cross-arch totals are NOT rolled into the
+                    # return tuple -- they measure hardware delta, not branch
+                    # regression.
+            comparison_summary = "\n".join(
+                r[5] for r in per_arch_results if r[3] and r[5]
             )
+    else:
+        # Legacy single-arch path: preserved byte-for-byte by delegating to
+        # _render_section with the original arch pair + the full env block
+        # (running platform, triggering env, arch, deployment) inline.
+        section_md, totals, had_data, local_regressions, local_summary = (
+            _render_section(
+                rts,
+                tf_github_org,
+                tf_github_repo,
+                tf_triggering_env,
+                metric_name,
+                baseline_branch,
+                comparison_branch,
+                baseline_tag,
+                comparison_tag,
+                baseline_deployment_name,
+                comparison_deployment_name,
+                print_improvements_only,
+                print_regressions_only,
+                skip_unstable,
+                regressions_percent_lower_limit,
+                args.regressions_percent_lower_limit,
+                simplify_table,
+                test,
+                testname_regex,
+                verbose,
+                last_n_baseline,
+                last_n_comparison,
+                metric_mode,
+                from_date,
+                from_ts_ms,
+                to_date,
+                to_ts_ms,
+                use_metric_context_path,
+                running_platform,
+                baseline_architecture,
+                comparison_architecture,
+                first_n_baseline,
+                first_n_comparison,
+                grafana_link_base,
+            )
+        )
+        if had_data:
+            comment_body = "### Automated performance analysis summary\n\n"
+            comment_body += (
+                "This comment was automatically generated given there is "
+                "performance data available.\n\n"
+            )
+            env_lines = _build_env_lines(
+                running_platform,
+                tf_triggering_env,
+                baseline_architecture,
+                comparison_architecture,
+                baseline_deployment_name,
+                comparison_deployment_name,
+                include_arch=True,
+                include_deployment=True,
+            )
+            if env_lines:
+                comment_body += "**Environment:**\n" + "\n".join(env_lines) + "\n\n"
+            comment_body += section_md
+            _accumulate(totals, local_regressions)
+            comparison_summary = local_summary
 
-        comment_body += "\n\n##" + table_output
+    # ------------------------------------------------------------------
+    # Upsert the PR comment (shared between legacy + multi-arch paths).
+    # ------------------------------------------------------------------
+    if comment_body:
         print(comment_body)
-
         if is_actionable_pr:
             zset_project_pull_request = get_project_compare_zsets(
                 tf_triggering_env,
@@ -477,7 +814,7 @@ def compare_command_logic(args, project_name, project_version):
             )
             user_input = "n"
             html_url = "n/a"
-            regression_count = len(detected_regressions)
+            regression_count = len(aggregated_detected_regressions)
             (
                 baseline_str,
                 by_str_baseline,
@@ -576,16 +913,16 @@ def compare_command_logic(args, project_name, project_version):
     else:
         logging.error("There was no comparison points to produce a table...")
     return (
-        detected_regressions,
+        aggregated_detected_regressions,
         comment_body,
-        total_improvements,
-        total_regressions,
-        total_stable,
-        total_unstable,
-        total_comparison_points,
-        total_unstable_baseline,
-        total_unstable_comparison,
-        total_latency_confirmed_regressions,
+        aggregated_totals["total_improvements"],
+        aggregated_totals["total_regressions"],
+        aggregated_totals["total_stable"],
+        aggregated_totals["total_unstable"],
+        aggregated_totals["total_comparison_points"],
+        aggregated_totals["total_unstable_baseline"],
+        aggregated_totals["total_unstable_comparison"],
+        aggregated_totals["total_latency_confirmed_regressions"],
     )
 
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -44,35 +44,42 @@ def _export_benchmark_data(
     github_org: str,
     github_repo: str,
     triggering_env: str = "circleci",
+    architecture: Optional[str] = None,
 ) -> None:
-    """Helper to export benchmark data."""
+    """Helper to export benchmark data.
+
+    When `architecture` is provided, passes `--architecture <value>` to the
+    exporter so the pushed time-series carry that arch tag (needed by
+    multi-arch compare tests that filter on `arch=aarch64` etc.).
+    """
     parser = argparse.ArgumentParser(
         description="test",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser = create_export_arguments(parser)
-    args = parser.parse_args(
-        args=[
-            "--results-format",
-            "google.benchmark",
-            "--benchmark-result-file",
-            "./tests/test_data/results/google.benchmark.json",
-            "--redistimeseries_host",
-            rts_host,
-            "--redistimeseries_port",
-            "{}".format(rts_port),
-            "--redistimeseries_pass",
-            "{}".format(rts_pass),
-            "--github_branch",
-            github_branch,
-            "--github_org",
-            github_org,
-            "--github_repo",
-            github_repo,
-            "--triggering_env",
-            triggering_env,
-        ]
-    )
+    cli_args = [
+        "--results-format",
+        "google.benchmark",
+        "--benchmark-result-file",
+        "./tests/test_data/results/google.benchmark.json",
+        "--redistimeseries_host",
+        rts_host,
+        "--redistimeseries_port",
+        "{}".format(rts_port),
+        "--redistimeseries_pass",
+        "{}".format(rts_pass),
+        "--github_branch",
+        github_branch,
+        "--github_org",
+        github_org,
+        "--github_repo",
+        github_repo,
+        "--triggering_env",
+        triggering_env,
+    ]
+    if architecture is not None:
+        cli_args += ["--architecture", architecture]
+    args = parser.parse_args(args=cli_args)
     try:
         export_command_logic(args, "tool", "v0")
     except SystemExit as e:
@@ -89,37 +96,47 @@ def _run_comparison(
     github_repo: str,
     metric_name: str = "cpu_time",
     triggering_env: str = "circleci",
+    architectures: Optional[str] = None,
+    no_cross_arch: bool = False,
 ) -> CompareResult:
-    """Helper to run comparison logic."""
+    """Helper to run comparison logic.
+
+    When `architectures` is provided (e.g. "x86_64,aarch64"), invokes the
+    multi-arch rendering path; the returned comment_body will contain one
+    H2 section per arch plus an optional cross-arch section.
+    """
     parser = argparse.ArgumentParser(
         description="test",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser = create_compare_arguments(parser)
-    args = parser.parse_args(
-        args=[
-            "--redistimeseries_host",
-            rts_host,
-            "--redistimeseries_port",
-            "{}".format(rts_port),
-            "--redistimeseries_pass",
-            "{}".format(rts_pass),
-            "--baseline-branch",
-            baseline_branch,
-            "--comparison-branch",
-            comparison_branch,
-            "--github_org",
-            github_org,
-            "--github_repo",
-            github_repo,
-            "--metric_name",
-            metric_name,
-            "--to-date",
-            "2100-01-01",
-            "--triggering_env",
-            triggering_env,
-        ]
-    )
+    cli_args = [
+        "--redistimeseries_host",
+        rts_host,
+        "--redistimeseries_port",
+        "{}".format(rts_port),
+        "--redistimeseries_pass",
+        "{}".format(rts_pass),
+        "--baseline-branch",
+        baseline_branch,
+        "--comparison-branch",
+        comparison_branch,
+        "--github_org",
+        github_org,
+        "--github_repo",
+        github_repo,
+        "--metric_name",
+        metric_name,
+        "--to-date",
+        "2100-01-01",
+        "--triggering_env",
+        triggering_env,
+    ]
+    if architectures is not None:
+        cli_args += ["--architectures", architectures]
+    if no_cross_arch:
+        cli_args += ["--no-cross-arch"]
+    args = parser.parse_args(args=cli_args)
     return CompareResult(*compare_command_logic(args, "tool", "v0"))
 
 
@@ -222,3 +239,191 @@ def test_compare_filters_applied_to_timeseries_queries() -> None:
         rts_host, rts_port, rts_pass, "baseline", "feature", "wrong-org", "test-repo"
     )
     assert result.total_comparison_points == 0
+
+
+# ----------------------------------------------------------------------
+# Multi-arch comment tests (--architectures / --no-cross-arch)
+# ----------------------------------------------------------------------
+
+
+def test_compare_single_arch_backwards_compat() -> None:
+    """Default invocation (no --architectures) must keep the legacy body
+    shape: no per-arch H2 sections, no cross-arch section."""
+    conn = _get_redis_connection()
+    if conn is None:
+        pytest.skip("Redis not available (RTS_DATASINK_HOST or RTS_PORT not set)")
+    rts, rts_host, rts_port, rts_pass = conn
+    rts.flushall()
+
+    _export_benchmark_data(rts_host, rts_port, rts_pass, "master", "org", "repo")
+    _export_benchmark_data(rts_host, rts_port, rts_pass, "feature", "org", "repo")
+    result = _run_comparison(
+        rts_host, rts_port, rts_pass, "master", "feature", "org", "repo"
+    )
+    assert "Automated performance analysis summary" in result.comment_body
+    assert "## Architecture: `x86_64` — branch-over-branch" not in result.comment_body
+    assert "## Cross-arch delta" not in result.comment_body
+
+
+def test_compare_architectures_two_archs_produces_three_sections() -> None:
+    """--architectures x86_64,aarch64 with data on both archs emits one
+    branch-over-branch section per arch plus a cross-arch section."""
+    conn = _get_redis_connection()
+    if conn is None:
+        pytest.skip("Redis not available (RTS_DATASINK_HOST or RTS_PORT not set)")
+    rts, rts_host, rts_port, rts_pass = conn
+    rts.flushall()
+
+    # Push both baseline and comparison data for both archs so each arch's
+    # branch-over-branch section has data AND the cross-arch section has
+    # data on the comparison branch.
+    for branch in ("master", "feature"):
+        for arch in ("x86_64", "aarch64"):
+            _export_benchmark_data(
+                rts_host,
+                rts_port,
+                rts_pass,
+                branch,
+                "org",
+                "repo",
+                architecture=arch,
+            )
+    result = _run_comparison(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "feature",
+        "org",
+        "repo",
+        architectures="x86_64,aarch64",
+    )
+    assert "## Architecture: `x86_64` — branch-over-branch" in result.comment_body
+    assert "## Architecture: `aarch64` — branch-over-branch" in result.comment_body
+    assert "## Cross-arch delta on `feature`" in result.comment_body
+    assert "(`x86_64` → `aarch64`)" in result.comment_body
+    # aggregated totals cover both per-arch sections (cross-arch is display-only)
+    assert result.total_comparison_points > 0
+
+
+def test_compare_architectures_missing_arch_shows_warning() -> None:
+    """When --architectures lists an arch that has no data, that section
+    renders a warning block and the cross-arch section is suppressed."""
+    conn = _get_redis_connection()
+    if conn is None:
+        pytest.skip("Redis not available (RTS_DATASINK_HOST or RTS_PORT not set)")
+    rts, rts_host, rts_port, rts_pass = conn
+    rts.flushall()
+
+    # Only x86_64 gets data; aarch64 intentionally missing.
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "org",
+        "repo",
+        architecture="x86_64",
+    )
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "feature",
+        "org",
+        "repo",
+        architecture="x86_64",
+    )
+    result = _run_comparison(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "feature",
+        "org",
+        "repo",
+        architectures="x86_64,aarch64",
+    )
+    assert "## Architecture: `x86_64` — branch-over-branch" in result.comment_body
+    assert "## Architecture: `aarch64` — branch-over-branch" in result.comment_body
+    assert "⚠️ No `aarch64` benchmark data found" in result.comment_body
+    # Without data on both archs the cross-arch delta is not emitted.
+    assert "## Cross-arch delta" not in result.comment_body
+
+
+def test_compare_architectures_no_cross_arch_flag_skips_cross_section() -> None:
+    """--no-cross-arch must suppress the cross-arch section even when both
+    archs have data."""
+    conn = _get_redis_connection()
+    if conn is None:
+        pytest.skip("Redis not available (RTS_DATASINK_HOST or RTS_PORT not set)")
+    rts, rts_host, rts_port, rts_pass = conn
+    rts.flushall()
+
+    for branch in ("master", "feature"):
+        for arch in ("x86_64", "aarch64"):
+            _export_benchmark_data(
+                rts_host,
+                rts_port,
+                rts_pass,
+                branch,
+                "org",
+                "repo",
+                architecture=arch,
+            )
+    result = _run_comparison(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "feature",
+        "org",
+        "repo",
+        architectures="x86_64,aarch64",
+        no_cross_arch=True,
+    )
+    assert "## Architecture: `x86_64` — branch-over-branch" in result.comment_body
+    assert "## Architecture: `aarch64` — branch-over-branch" in result.comment_body
+    assert "## Cross-arch delta" not in result.comment_body
+
+
+def test_compare_architectures_single_entry_no_cross_arch() -> None:
+    """--architectures with a single entry (e.g. 'x86_64') produces one
+    section and no cross-arch delta -- there's nothing to cross-compare."""
+    conn = _get_redis_connection()
+    if conn is None:
+        pytest.skip("Redis not available (RTS_DATASINK_HOST or RTS_PORT not set)")
+    rts, rts_host, rts_port, rts_pass = conn
+    rts.flushall()
+
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "org",
+        "repo",
+        architecture="x86_64",
+    )
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "feature",
+        "org",
+        "repo",
+        architecture="x86_64",
+    )
+    result = _run_comparison(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "feature",
+        "org",
+        "repo",
+        architectures="x86_64",
+    )
+    assert "## Architecture: `x86_64` — branch-over-branch" in result.comment_body
+    assert "## Architecture: `aarch64`" not in result.comment_body
+    assert "## Cross-arch delta" not in result.comment_body


### PR DESCRIPTION
## Summary

Adds `--architectures` (comma-separated, e.g. `x86_64,aarch64`) and `--no-cross-arch` to `redisbench-admin compare`. When `--architectures` has ≥ 2 values, the PR comment body now contains:

1. **One H2 section per arch** — `## Architecture: \`<arch>\` — branch-over-branch` (baseline vs comparison branch, scoped to that arch's RTS time-series).
2. **Cross-arch delta section** — `## Cross-arch delta on \`<comparison_branch>\` (\`x86_64\` → \`aarch64\`)`. Same commit compared across architectures; positive deltas = aarch64 outperforms x86_64. Display-only, not rolled into the return tuple.
3. **Empty-arch warning** — when a listed arch has no RTS data (e.g. upstream modules without ARM CI runners yet), a ⚠️ block is emitted in place of the table and the cross-arch section is skipped.

The top-level `**Environment:**` block drops the per-arch/per-deployment lines in multi-arch mode (they move into each section's header) and keeps only the shared dimensions (running platform, triggering env).

## Why

RediSearch CI now runs both x86_64 and aarch64 benchmark tracks ([#9258](https://github.com/RediSearch/RediSearch/pull/9258)). The prior design had one `compare` invocation per matrix entry, each upserting the same comment — last write wins, so cross-arch coverage was silently incomplete. This change lets the workflow call `compare` once with `--architectures x86_64,aarch64` and produce a single stable comment covering both archs plus a cross-arch delta.

## Backwards compatibility

Legacy single-arch invocation (no `--architectures`, callers still passing `--baseline_architecture` / `--comparison_architecture`) is preserved byte-for-byte through shared `_render_section()` / `_build_env_lines()` helpers. The existing tests (`test_compare_command_logic`, `test_compare_with_org_repo_filtering`, `test_compare_filters_applied_to_timeseries_queries`) regress this.

## New tests

| Test | What it proves |
|---|---|
| `test_compare_single_arch_backwards_compat` | No `--architectures` → legacy body shape (no H2 per-arch, no cross-arch) |
| `test_compare_architectures_two_archs_produces_three_sections` | Both archs populated → 2 per-arch sections + cross-arch |
| `test_compare_architectures_missing_arch_shows_warning` | aarch64 has no data → warning block, cross-arch suppressed |
| `test_compare_architectures_no_cross_arch_flag_skips_cross_section` | `--no-cross-arch` suppresses cross-arch even with data on both |
| `test_compare_architectures_single_entry_no_cross_arch` | Single arch in list → 1 section, no cross-arch |

Existing tests also extended: `_export_benchmark_data` accepts an `architecture` kwarg so tests can push per-arch synthetic data to RTS.

## Release

Bumps `pyproject.toml` to `0.12.25`. After merge, cut the `v0.12.25` tag to publish to PyPI; RediSearch `perf-arm-ci-runners` will swap its `compare` flags to `--architectures x86_64,aarch64` in a follow-up.