### PR TITLE
compare: decouple cross-arch section from branch-over-branch gating (0.12.26)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.25"
+version = "0.12.26"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/compare/compare.py
+++ b/redisbench_admin/compare/compare.py
@@ -658,11 +658,17 @@ def compare_command_logic(args, project_name, project_version):
                     comment_body += _missing_arch_warning(arch, comparison_branch)
 
             # Cross-arch delta section: both sides on the comparison branch,
-            # architectures differ. Rendered only when we have >=2 archs
-            # with data AND the user didn't opt out via --no-cross-arch.
-            archs_with_data = [r[0] for r in per_arch_results if r[3]]
-            if len(archs_with_data) >= 2 and not getattr(args, "no_cross_arch", False):
-                xa_baseline, xa_comparison = archs_with_data[0], archs_with_data[1]
+            # architectures differ. Gated ONLY on "user requested >=2 archs"
+            # + "didn't opt out"; NOT on whether branch-over-branch had data
+            # for each arch. The cross-arch comparison is valuable even on
+            # bootstrap PRs -- e.g. the first PR to introduce aarch64 has no
+            # aarch64 baseline on master (so that arch's branch-over-branch
+            # warns empty), but x86 and aarch64 data both exist on the PR
+            # commit itself, which is exactly what cross-arch wants to
+            # compare. We delegate the data-presence check to _render_section;
+            # if it returns had_data=False the section is simply omitted.
+            if len(multi_archs) >= 2 and not getattr(args, "no_cross_arch", False):
+                xa_baseline, xa_comparison = multi_archs[0], multi_archs[1]
                 (
                     xa_section_md,
                     _,

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -387,6 +387,72 @@ def test_compare_architectures_no_cross_arch_flag_skips_cross_section() -> None:
     assert "## Cross-arch delta" not in result.comment_body
 
 
+def test_compare_architectures_cross_arch_emits_without_aarch64_baseline() -> None:
+    """Bootstrap case: the PR introducing aarch64 has x86_64 baseline data on
+    master but NO aarch64 data on master. aarch64 branch-over-branch should
+    warn (no baseline), but the cross-arch delta MUST still render because
+    both archs have data on the PR (comparison) branch -- that's the whole
+    point of cross-arch.
+
+    Regression test for the 0.12.25 bug where cross-arch was gated on
+    len(archs_with_data) >= 2, suppressing it whenever one arch's
+    branch-over-branch had no baseline.
+    """
+    conn = _get_redis_connection()
+    if conn is None:
+        pytest.skip("Redis not available (RTS_DATASINK_HOST or RTS_PORT not set)")
+    rts, rts_host, rts_port, rts_pass = conn
+    rts.flushall()
+
+    # master: x86_64 only (simulates no ARM CI on master yet)
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "org",
+        "repo",
+        architecture="x86_64",
+    )
+    # feature branch: BOTH archs (the PR introduces aarch64 CI)
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "feature",
+        "org",
+        "repo",
+        architecture="x86_64",
+    )
+    _export_benchmark_data(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "feature",
+        "org",
+        "repo",
+        architecture="aarch64",
+    )
+    result = _run_comparison(
+        rts_host,
+        rts_port,
+        rts_pass,
+        "master",
+        "feature",
+        "org",
+        "repo",
+        architectures="x86_64,aarch64",
+    )
+    # aarch64 branch-over-branch still warns -- no aarch64 baseline on master.
+    assert "## Architecture: `x86_64` — branch-over-branch" in result.comment_body
+    assert "## Architecture: `aarch64` — branch-over-branch" in result.comment_body
+    assert "No `aarch64` benchmark data found" in result.comment_body
+    # Cross-arch MUST still render -- both archs have data on the feature
+    # branch so the delta is well-defined.
+    assert "## Cross-arch delta on `feature`" in result.comment_body
+    assert "(`x86_64` → `aarch64`)" in result.comment_body
+
+
 def test_compare_architectures_single_entry_no_cross_arch() -> None:
     """--architectures with a single entry (e.g. 'x86_64') produces one
     section and no cross-arch delta -- there's nothing to cross-compare."""


### PR DESCRIPTION
## Bug

0.12.25 gated the `## Cross-arch delta` section on `len(archs_with_data) >= 2` where `archs_with_data` was the subset of per-arch sections that had **branch-over-branch** data. This silently suppressed cross-arch on any PR where one arch lacked a baseline on `master` — notably the bootstrap PR that introduces aarch64 CI ([RediSearch #9258](https://github.com/RediSearch/RediSearch/pull/9258)):

- `x86_64` had a years-long master baseline → full table renders
- `aarch64` had no master data → correctly rendered the "no baseline" warning
- **Cross-arch ALSO got skipped** — even though both archs had data on the PR commit itself, which is exactly what cross-arch compares

## Fix

Switch the gate to `len(multi_archs) >= 2` (user requested ≥2 archs + didn't opt out) and let `_render_section`'s own `had_data` check drop the section when cross-arch itself has no comparison points.

## Test

Adds `test_compare_architectures_cross_arch_emits_without_aarch64_baseline`:

```python
# master: x86_64 only (simulates no ARM CI on master yet)
# feature: BOTH archs (the PR introduces aarch64 CI)
result = _run_comparison(..., architectures="x86_64,aarch64")

# aarch64 branch-over-branch still warns -- no baseline
assert "No `aarch64` benchmark data found" in result.comment_body
# Cross-arch MUST render -- both archs have data on feature
assert "## Cross-arch delta on `feature`" in result.comment_body
```

## Release

Bumps `pyproject.toml` 0.12.25 → 0.12.26.