### PR TITLE
metrics: fix section_filter no-op on scalars (operator precedence) — 0.12.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.26"
+version = "0.12.28"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run/metrics.py
+++ b/redisbench_admin/run/metrics.py
@@ -110,7 +110,7 @@ def collect_redis_metrics(
                         if section in section_filter:
                             if k not in section_filter[section]:
                                 collect = False
-                    if collect and type(v) is float or type(v) is int:
+                    if collect and (type(v) is float or type(v) is int):
                         if k not in overall[section]:
                             overall[section][k] = 0
                         overall[section][k] += v

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,6 +5,8 @@
 #
 import json
 import os
+from unittest.mock import MagicMock
+
 import redis
 import yaml
 
@@ -68,3 +70,54 @@ def test_collect_redis_metrics():
     assert "commandstats_cmdstat_ping_calls_shard_2" in overall_metrics
     assert "latencystats_latency_percentiles_usec_ping_p50_shard_1" in overall_metrics
     assert "latencystats_latency_percentiles_usec_ping_p50_shard_2" in overall_metrics
+
+
+def test_collect_redis_metrics_section_filter_drops_scalar_keys():
+    """The section_filter is meant to restrict which INFO keys make it into
+    the overall map. Prior to this test it was silently broken for scalar
+    (int/float) values due to Python operator precedence on
+    `if collect and type(v) is float or type(v) is int` -- the `or` binds
+    last, so the `collect` flag was effectively ignored whenever v was an
+    int, and filtered-out keys leaked through. Lock in the intended
+    semantics: only keys listed in section_filter[section] end up in the
+    flat overall dict; the rest are dropped."""
+    conn = MagicMock()
+
+    def _info(section):
+        return {
+            "section_a": {"keep_me": 10, "drop_me": 20, "also_drop": 30.5},
+            "section_b": {"included_b": 100, "excluded_b": 200},
+        }.get(section, {})
+
+    conn.info.side_effect = _info
+    _, _, overall = collect_redis_metrics(
+        [conn],
+        sections=["section_a", "section_b"],
+        section_filter={
+            "section_a": ["keep_me"],
+            "section_b": ["included_b"],
+        },
+    )
+    assert "section_a_keep_me" in overall
+    assert overall["section_a_keep_me"] == 10
+    assert "section_b_included_b" in overall
+    assert overall["section_b_included_b"] == 100
+    # The filtered-out keys must not appear in the overall dict.
+    assert "section_a_drop_me" not in overall
+    assert "section_a_also_drop" not in overall
+    assert "section_b_excluded_b" not in overall
+
+
+def test_collect_redis_metrics_no_filter_keeps_all_scalars():
+    """When section_filter is None, every scalar INFO key is collected --
+    this is the legacy default and the common code path. Regression check
+    to ensure the operator-precedence fix didn't accidentally flip the
+    default to 'filter everything out'."""
+    conn = MagicMock()
+    conn.info.side_effect = lambda section: (
+        {"alpha": 1, "beta": 2, "gamma": 3} if section == "section_a" else {}
+    )
+    _, _, overall = collect_redis_metrics([conn], sections=["section_a"])
+    assert overall["section_a_alpha"] == 1
+    assert overall["section_a_beta"] == 2
+    assert overall["section_a_gamma"] == 3


### PR DESCRIPTION
## Bug

\`collect_redis_metrics\`'s \`section_filter\` was silently a no-op for scalar (int/float) values:

\`\`\`python
if collect and type(v) is float or type(v) is int:
\`\`\`

Python parses this as \`(collect and type(v) is float) or (type(v) is int)\` (because \`or\` binds looser than \`and\`). So when \`v\` was an int — the majority of Redis INFO fields — the \`collect\` flag carrying the filter decision was **ignored** and the key went through regardless of whether the caller had whitelisted it.

Surfaced while adding tests for \`collect_search_and_bigredis_metrics\` in #531: a strict assertion caught it, I relaxed the test to match actual behavior and flagged this as a follow-up. This is that follow-up.

## Impact

Every caller of \`collect_redis_metrics\` that passed a \`section_filter\` was getting every int-valued key in the section rather than just the whitelisted ones. In particular, \`collect_search_and_bigredis_metrics\` (merged in #531) returned **every** scalar from bigredis / search_memory / search_disk INFO, not the four documented keys. With this fix it returns strictly the documented keys.

## Fix

One-char change — add parentheses:

\`\`\`diff
-                    if collect and type(v) is float or type(v) is int:
+                    if collect and (type(v) is float or type(v) is int):
\`\`\`

## Tests

Two new mock-based regression tests in \`tests/test_metrics.py\`:

| Test | What it locks in |
|---|---|
| \`test_collect_redis_metrics_section_filter_drops_scalar_keys\` | With a filter, only whitelisted keys appear in the overall map — both ints AND floats, in both of the two sections under test |
| \`test_collect_redis_metrics_no_filter_keeps_all_scalars\` | Legacy default path (no filter) still collects every scalar. Guards against accidentally inverting the fix |

## Release

Bumps \`pyproject.toml\` 0.12.26 → 0.12.28 (skipping .27, which is #531's in-flight release).