### PR TITLE
metrics: skip None / non-numeric metric values instead of crashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.28"
+version = "0.12.29"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run/metrics.py
+++ b/redisbench_admin/run/metrics.py
@@ -49,7 +49,22 @@ def extract_results_table(
                     use_metric_context_path = True
                 for metric in find_res:
                     metric_name = str(metric.path)
-                    metric_value = float(metric.value)
+                    if metric.value is None:
+                        logging.warning(
+                            "Skipping metric {} (path: {}) because its value is None".format(
+                                metric_jsonpath, metric_name
+                            )
+                        )
+                        continue
+                    try:
+                        metric_value = float(metric.value)
+                    except (TypeError, ValueError):
+                        logging.warning(
+                            "Skipping metric {} (path: {}) because its value {!r} is not numeric".format(
+                                metric_jsonpath, metric_name, metric.value
+                            )
+                        )
+                        continue
                     metric_context_path = str(metric.context.path)
                     if metric_jsonpath[0] == "$":
                         metric_jsonpath = metric_jsonpath[1:]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,6 +38,54 @@ def test_extract_results_table():
             )
 
 
+def test_extract_results_table_skips_none_values():
+    """Some tools (notably memtier_benchmark with multiple ``--command``
+    flags driving a mixed read/write workload) emit result JSON where a
+    wildcard JSONPath match yields ``None`` for one of the per-command
+    sub-stats. ``extract_results_table`` used to crash with
+    ``TypeError: float() argument must be a string or a real number,
+    not 'NoneType'`` on those rows. Verify it now skips them gracefully
+    and still emits the rows that do have numeric values.
+    """
+    results_dict = {
+        "ALL STATS": {
+            "Totals": {"Ops/sec": 12345.0, "Latency": 1.5},
+            "Cmd_A": {"Ops/sec": 100.0, "Latency": 5.0},
+            "Cmd_B": {"Ops/sec": None, "Latency": None},
+        }
+    }
+    metrics = [
+        '$."ALL STATS".*."Ops/sec"',
+        '$."ALL STATS".*."Latency"',
+    ]
+    rows = extract_results_table(metrics, results_dict)
+    # Two wildcards x three sub-keys = 6 candidates; 2 are None and must
+    # be skipped, leaving 4 numeric rows.
+    assert len(rows) == 4
+    for row in rows:
+        # row layout:
+        # [metric_jsonpath, metric_context_path, metric_name,
+        #  metric_value, test_case_targets_dict, use_metric_context_path]
+        assert row[3] is not None
+        assert isinstance(row[3], float)
+
+
+def test_extract_results_table_skips_non_numeric_values():
+    """Defensive check: if a tool emits a string (e.g. ``"--"`` placeholder)
+    where a numeric metric is expected, ``extract_results_table`` should
+    skip that entry instead of raising ``ValueError``."""
+    results_dict = {
+        "ALL STATS": {
+            "Totals": {"Ops/sec": 100.0},
+            "Empty": {"Ops/sec": "--"},
+        }
+    }
+    metrics = ['$."ALL STATS".*."Ops/sec"']
+    rows = extract_results_table(metrics, results_dict)
+    assert len(rows) == 1
+    assert rows[0][3] == 100.0
+
+
 def test_collect_redis_metrics():
     import os
     import pytest


### PR DESCRIPTION
## Summary
- \`extract_results_table\` called \`float(metric.value)\` unconditionally, so any JSONPath match that resolved to \`None\` (or a non-numeric placeholder) raised \`TypeError\` / \`ValueError\` and aborted the entire benchmark run during the export step.
- This surfaced on RediSearch CI for the new \`search-expire-doc-10-milliseconds\` benchmark: a memtier_benchmark *mixed* workload with two \`--command\` flags. The per-command \`\"ALL STATS\"\` sub-sections occasionally lack \`Ops/sec\` / \`Latency\`, so the default wildcard exporter metrics (\`$.\"ALL STATS\".*.\"Ops/sec\"\` / \`.Latency\` from \`defaults.yml\`) handed \`None\` to \`extract_results_table\` during post-benchmark export. The benchmark itself ran fine, but the run was reported as a failure. See the failing CI job at https://github.com/RediSearch/RediSearch/actions/runs/24993907300/job/73187554336 — full traceback at \`redisbench_admin/run/metrics.py:52\`:
  \`\`\`
  TypeError: float() argument must be a string or a real number, not 'NoneType'
  \`\`\`
- This change skips those entries with a warning, keeps the numeric ones, and lets the run finish.

## Test plan
- [x] \`tox -e compliance\` (black + flake8) — green locally
- [x] \`poetry run pytest tests/test_metrics.py -v\` — 9 passed, 1 skipped (RTS env not set locally)
- [x] New \`test_extract_results_table_skips_none_values\` reproduces the original crash via a synthetic results dict where a wildcard JSONPath match yields \`None\`; passes after the fix.
- [x] New \`test_extract_results_table_skips_non_numeric_values\` covers the \`\"--\"\` placeholder string case (defensive — same fix branch).
- [ ] Full \`tox\` matrix (Python 3.11/3.12/3.13/3.14) on CI.