### PR TITLE
pass new argument to ftsb and try reconnecting on SSH failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.30"
+version = "0.12.31"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run/ftsb/ftsb.py
+++ b/redisbench_admin/run/ftsb/ftsb.py
@@ -55,6 +55,8 @@ def prepare_ftsb_benchmark_command(
                     command_arr.extend(["--max-token-size-mb", str(value)])
                 elif key in ("batch-size", "batch_size"):
                     command_arr.extend(["--batch-size", str(value)])
+                elif key in ("max-latency-seconds", "max_latency_seconds"):
+                    command_arr.extend(["--max-latency-seconds", str(value)])
                 else:
                     command_arr.extend(["--{}".format(key), str(value)])
 
@@ -75,6 +77,13 @@ def prepare_ftsb_benchmark_command(
                     elif "batch-size" in k or "batch_size" in k:
                         bs_key = "batch-size" if "batch-size" in k else "batch_size"
                         command_arr.extend(["--batch-size", str(k[bs_key])])
+                    elif "max-latency-seconds" in k or "max_latency_seconds" in k:
+                        mls_key = (
+                            "max-latency-seconds"
+                            if "max-latency-seconds" in k
+                            else "max_latency_seconds"
+                        )
+                        command_arr.extend(["--max-latency-seconds", str(k[mls_key])])
                     else:
                         for kk in k.keys():
                             command_arr.extend(["--{}".format(kk), str(k[kk])])

--- a/redisbench_admin/run/ssh.py
+++ b/redisbench_admin/run/ssh.py
@@ -45,6 +45,7 @@ def ssh_tunnel_redisconn(
         ),  # remote redis server
         # Bind the socket to port 0. A random free port from 1024 to 65535 will be selected.
         local_bind_address=("0.0.0.0", 0),  # enable local forwarding port
+        set_keepalive=30,  # send SSH keepalive every 30 seconds to prevent stale tunnels
     )
     ssh_tunel.start()  # start tunnel
     redis_conn = redis.Redis(

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -739,6 +739,12 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 ssh_tunnel,
                                                 full_logfiles,
                                                 remote_temporary_dir,
+                                                server_private_ip=server_private_ip,
+                                                server_public_ip=server_public_ip,
+                                                username=username,
+                                                db_ssh_port=db_ssh_port,
+                                                private_key=private_key,
+                                                redis_password=redis_password,
                                             )
                                             # Update tracker with PIDs after ro_benchmark_set stores them
                                             if setup_details.get(
@@ -1796,6 +1802,75 @@ def run_remote_command_logic(args, project_name, project_version):
     exit(return_code)
 
 
+def _try_get_redis_pids(redis_conns):
+    """Attempt to get Redis PIDs from connections. Returns (pids, all_failed)."""
+    pids = []
+    failures = 0
+    for conn in redis_conns:
+        try:
+            info = conn.info("server")
+            pids.append(info.get("process_id", None))
+        except Exception as e:
+            logging.warning(f"Failed to get PID from Redis connection: {e}")
+            pids.append(None)
+            failures += 1
+    all_failed = failures == len(redis_conns) and len(redis_conns) > 0
+    return pids, all_failed
+
+
+def _reconnect_ssh_tunnel_and_redis(setup_details):
+    """Re-establish SSH tunnel and Redis connections using stored parameters.
+
+    Returns (new_redis_conns, new_ssh_tunnel) or raises if reconnection fails.
+    """
+    from redisbench_admin.run.ssh import ssh_tunnel_redisconn
+
+    env = setup_details["env"]
+    server_private_ip = env.get("server_private_ip")
+    server_public_ip = env.get("server_public_ip")
+    username = env.get("username")
+    db_ssh_port = env.get("db_ssh_port", 22)
+    private_key = env.get("private_key")
+    redis_password = env.get("redis_password")
+    server_plaintext_port = env["server_plaintext_port"]
+
+    if not all([server_private_ip, server_public_ip, username, private_key]):
+        raise ConnectionError(
+            "Cannot reconnect SSH tunnel: missing connection parameters in "
+            "stored environment. Ensure ro_benchmark_set was called with "
+            "server_private_ip, server_public_ip, username, and private_key."
+        )
+
+    # Stop old tunnel gracefully
+    old_tunnel = env.get("ssh_tunnel")
+    if old_tunnel is not None:
+        try:
+            old_tunnel.stop()
+        except Exception:
+            pass
+
+    logging.info(
+        f"🔄 Attempting to re-establish SSH tunnel to "
+        f"{server_public_ip} -> {server_private_ip}:{server_plaintext_port}"
+    )
+    redis_conn, new_tunnel = ssh_tunnel_redisconn(
+        server_plaintext_port,
+        server_private_ip,
+        server_public_ip,
+        username,
+        db_ssh_port,
+        private_key,
+        redis_password,
+    )
+    logging.info("🟢 SSH tunnel and Redis connection re-established successfully")
+
+    # Update stored env so subsequent reuses also have fresh connections
+    env["redis_conns"] = [redis_conn]
+    env["ssh_tunnel"] = new_tunnel
+
+    return [redis_conn], new_tunnel
+
+
 def ro_benchmark_reuse(
     artifact_version,
     benchmark_type,
@@ -1832,14 +1907,28 @@ def ro_benchmark_reuse(
 
     # Verify Redis PIDs are the same (same Redis instance is being reused)
     expected_pids = setup_details["env"].get("redis_pids", [])
-    current_pids = []
-    for conn in redis_conns:
+    current_pids, all_failed = _try_get_redis_pids(redis_conns)
+
+    # If all connections failed, the SSH tunnel likely died — try to reconnect
+    if all_failed:
+        logging.warning(
+            "⚠️ All Redis connections failed. SSH tunnel may be stale. "
+            "Attempting to re-establish tunnel and connections..."
+        )
         try:
-            info = conn.info("server")
-            current_pids.append(info.get("process_id", None))
+            redis_conns, ssh_tunnel = _reconnect_ssh_tunnel_and_redis(setup_details)
+            current_pids, all_failed = _try_get_redis_pids(redis_conns)
+            if all_failed:
+                raise ConnectionError(
+                    "Redis connections still failing after SSH tunnel reconnection."
+                )
+        except ConnectionError:
+            raise
         except Exception as e:
-            logging.warning(f"Failed to get PID from Redis connection: {e}")
-            current_pids.append(None)
+            raise ConnectionError(
+                f"Failed to re-establish SSH tunnel and Redis connections: {e}"
+            ) from e
+
     pids_match = current_pids == expected_pids
     if pids_match:
         logging.info(
@@ -1886,6 +1975,12 @@ def ro_benchmark_set(
     ssh_tunnel,
     full_logfiles,
     remote_temporary_dir,
+    server_private_ip=None,
+    server_public_ip=None,
+    username=None,
+    db_ssh_port=22,
+    private_key=None,
+    redis_password=None,
 ):
     logging.info(
         "Given the benchmark for this setup is read-only we will prepare to reuse it on the next read-only benchmarks (if any )."
@@ -1903,6 +1998,14 @@ def ro_benchmark_set(
     setup_details["env"]["return_code"] = return_code
     setup_details["env"]["server_plaintext_port"] = server_plaintext_port
     setup_details["env"]["ssh_tunnel"] = ssh_tunnel
+
+    # Store SSH connection parameters for tunnel reconnection
+    setup_details["env"]["server_private_ip"] = server_private_ip
+    setup_details["env"]["server_public_ip"] = server_public_ip
+    setup_details["env"]["username"] = username
+    setup_details["env"]["db_ssh_port"] = db_ssh_port
+    setup_details["env"]["private_key"] = private_key
+    setup_details["env"]["redis_password"] = redis_password
 
     # Store Redis PIDs for verification when reusing
     redis_pids = []

--- a/tests/test_ftsb.py
+++ b/tests/test_ftsb.py
@@ -146,6 +146,34 @@ def test_prepare_ftsb_benchmark_command_batch_size(parameters, batch_value):
     assert command_arr[idx + 1] == batch_value
 
 
+@pytest.mark.parametrize(
+    "parameters,expected_value",
+    [
+        ([{"max-latency-seconds": 60}], "60"),
+        ([{"max_latency_seconds": 30}], "30"),
+        ({"max-latency-seconds": 60}, "60"),
+        ({"max_latency_seconds": 30}, "30"),
+    ],
+    ids=["list-hyphen", "list-underscore", "dict-hyphen", "dict-underscore"],
+)
+def test_prepare_ftsb_benchmark_command_max_latency_seconds(parameters, expected_value):
+    """Test max-latency-seconds is correctly passed for both config formats and key spellings."""
+    entry = {"parameters": parameters}
+    command_arr, command_str = prepare_ftsb_benchmark_command(
+        "ftsb_redisearch",
+        "localhost",
+        6379,
+        entry,
+        ".",
+        "/tmp/result.json",
+        "/tmp/input.data",
+        is_remote=False,
+    )
+    assert "--max-latency-seconds" in command_arr
+    idx = command_arr.index("--max-latency-seconds")
+    assert command_arr[idx + 1] == expected_value
+
+
 def test_extract_ftsb_extra_links():
     """Test extraction of ftsb extra links from config."""
     with open(

--- a/tests/test_run_remote_reconnect.py
+++ b/tests/test_run_remote_reconnect.py
@@ -1,0 +1,177 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2021., Redis Labs Modules
+#  All rights reserved.
+#
+"""Tests for the SSH-tunnel reconnection helpers in run_remote.
+
+Covers:
+- _try_get_redis_pids: success / partial-fail / all-fail / empty
+- _reconnect_ssh_tunnel_and_redis: missing-params guard, happy path with
+  env mutation, and old-tunnel-stop failure being swallowed.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from redisbench_admin.run_remote.run_remote import (
+    _reconnect_ssh_tunnel_and_redis,
+    _try_get_redis_pids,
+)
+
+
+def _conn_returning_pid(pid):
+    conn = MagicMock()
+    conn.info.return_value = {"process_id": pid}
+    return conn
+
+
+def _conn_raising(exc):
+    conn = MagicMock()
+    conn.info.side_effect = exc
+    return conn
+
+
+# ---------- _try_get_redis_pids ----------
+
+
+def test_try_get_redis_pids_all_success():
+    conns = [_conn_returning_pid(111), _conn_returning_pid(222)]
+    pids, all_failed = _try_get_redis_pids(conns)
+    assert pids == [111, 222]
+    assert all_failed is False
+
+
+def test_try_get_redis_pids_partial_failure_is_not_all_failed():
+    conns = [_conn_returning_pid(111), _conn_raising(ConnectionError("boom"))]
+    pids, all_failed = _try_get_redis_pids(conns)
+    assert pids == [111, None]
+    assert all_failed is False
+
+
+def test_try_get_redis_pids_all_failure_flags_all_failed():
+    conns = [
+        _conn_raising(ConnectionError("boom-1")),
+        _conn_raising(TimeoutError("boom-2")),
+    ]
+    pids, all_failed = _try_get_redis_pids(conns)
+    assert pids == [None, None]
+    assert all_failed is True
+
+
+def test_try_get_redis_pids_empty_conns_is_not_all_failed():
+    """Empty conn list shouldn't trigger reconnection logic."""
+    pids, all_failed = _try_get_redis_pids([])
+    assert pids == []
+    assert all_failed is False
+
+
+def test_try_get_redis_pids_missing_process_id_field_is_success():
+    """A response without 'process_id' yields None but is NOT a failure."""
+    conn = MagicMock()
+    conn.info.return_value = {"redis_version": "7.4.0"}  # no process_id
+    pids, all_failed = _try_get_redis_pids([conn])
+    assert pids == [None]
+    assert all_failed is False
+
+
+# ---------- _reconnect_ssh_tunnel_and_redis ----------
+
+
+def _full_env(**overrides):
+    env = {
+        "server_private_ip": "10.0.0.5",
+        "server_public_ip": "1.2.3.4",
+        "username": "ubuntu",
+        "db_ssh_port": 22,
+        "private_key": "/tmp/key.pem",
+        "redis_password": "secret",
+        "server_plaintext_port": 6379,
+        "ssh_tunnel": None,
+        "redis_conns": [],
+    }
+    env.update(overrides)
+    return env
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["server_private_ip", "server_public_ip", "username", "private_key"],
+)
+def test_reconnect_raises_when_required_param_missing(missing_field):
+    setup_details = {"env": _full_env(**{missing_field: None})}
+    with pytest.raises(ConnectionError, match="missing connection parameters"):
+        _reconnect_ssh_tunnel_and_redis(setup_details)
+
+
+def test_reconnect_happy_path_updates_env_and_returns_new_conn_and_tunnel():
+    new_conn = MagicMock(name="new_redis_conn")
+    new_tunnel = MagicMock(name="new_ssh_tunnel")
+
+    old_tunnel = MagicMock(name="old_ssh_tunnel")
+    setup_details = {"env": _full_env(ssh_tunnel=old_tunnel)}
+
+    with patch(
+        "redisbench_admin.run.ssh.ssh_tunnel_redisconn",
+        return_value=(new_conn, new_tunnel),
+    ) as mocked_setup:
+        conns, tunnel = _reconnect_ssh_tunnel_and_redis(setup_details)
+
+    # Old tunnel was stopped before opening the new one.
+    old_tunnel.stop.assert_called_once()
+
+    # ssh_tunnel_redisconn called with the params from env, in the expected order.
+    mocked_setup.assert_called_once_with(
+        6379,           # server_plaintext_port
+        "10.0.0.5",     # server_private_ip
+        "1.2.3.4",      # server_public_ip
+        "ubuntu",       # username
+        22,             # db_ssh_port
+        "/tmp/key.pem", # private_key
+        "secret",       # redis_password
+    )
+
+    # Return values
+    assert conns == [new_conn]
+    assert tunnel is new_tunnel
+
+    # env mutation so subsequent reuses see fresh state.
+    assert setup_details["env"]["redis_conns"] == [new_conn]
+    assert setup_details["env"]["ssh_tunnel"] is new_tunnel
+
+
+def test_reconnect_swallows_old_tunnel_stop_failure():
+    """If the dead tunnel raises on .stop(), reconnection should still proceed."""
+    new_conn = MagicMock()
+    new_tunnel = MagicMock()
+
+    flaky_old_tunnel = MagicMock()
+    flaky_old_tunnel.stop.side_effect = RuntimeError("tunnel already dead")
+    setup_details = {"env": _full_env(ssh_tunnel=flaky_old_tunnel)}
+
+    with patch(
+        "redisbench_admin.run.ssh.ssh_tunnel_redisconn",
+        return_value=(new_conn, new_tunnel),
+    ):
+        conns, tunnel = _reconnect_ssh_tunnel_and_redis(setup_details)
+
+    flaky_old_tunnel.stop.assert_called_once()
+    assert conns == [new_conn]
+    assert tunnel is new_tunnel
+
+
+def test_reconnect_handles_no_previous_tunnel():
+    """If env has no prior ssh_tunnel (None), reconnection still succeeds."""
+    new_conn = MagicMock()
+    new_tunnel = MagicMock()
+    setup_details = {"env": _full_env(ssh_tunnel=None)}
+
+    with patch(
+        "redisbench_admin.run.ssh.ssh_tunnel_redisconn",
+        return_value=(new_conn, new_tunnel),
+    ):
+        conns, tunnel = _reconnect_ssh_tunnel_and_redis(setup_details)
+
+    assert conns == [new_conn]
+    assert tunnel is new_tunnel
+    assert setup_details["env"]["ssh_tunnel"] is new_tunnel


### PR DESCRIPTION
## Summary
Two related improvements to remote benchmark runs:

1. **ftsb: pass `--max-latency-seconds` through.** Plumbs the new ftsb arg (added in ftsb #109, configurable HDR histogram latency cap) through `prepare_ftsb_benchmark_command`. Supports both the list-of-dicts and dict shapes and both `max-latency-seconds` / `max_latency_seconds` spellings, matching the existing `batch-size` handling.

2. **SSH tunnel: keepalive + auto-reconnect on stale tunnels.** Long-running read-only reuse paths sometimes hit a silently-dead SSH tunnel between benchmarks, surfacing as `redis_conn.info("server")` failures inside `ro_benchmark_reuse`. Two changes address this:
   - `ssh_tunnel_redisconn` now sets `set_keepalive=30` on the `SSHTunnelForwarder` so the tunnel is kept warm.
   - When all reused Redis connections fail PID verification, `ro_benchmark_reuse` now tries to re-establish the SSH tunnel (using connection params now stashed in `setup_details["env"]` by `ro_benchmark_set`) before failing. Helpers `_try_get_redis_pids` and `_reconnect_ssh_tunnel_and_redis` keep the logic isolated and unit-testable.

## Files
- `redisbench_admin/run/ftsb/ftsb.py` — `--max-latency-seconds` plumbing for both config shapes / spellings.
- `redisbench_admin/run/ssh.py` — `set_keepalive=30` on `SSHTunnelForwarder`.
- `redisbench_admin/run_remote/run_remote.py` — `_try_get_redis_pids`, `_reconnect_ssh_tunnel_and_redis`, and updated `ro_benchmark_set` / `ro_benchmark_reuse` to store + use SSH connection params.
- `tests/test_ftsb.py` — parametrized test for `--max-latency-seconds`.
- `tests/test_run_remote_reconnect.py` — unit tests for the reconnection helpers.
- `pyproject.toml` — version bump 0.12.30 → 0.12.31.

## Test plan
- [x] `pytest tests/test_ftsb.py` — 13 passed (4 new for `max-latency-seconds`).
- [x] `pytest tests/test_run_remote_reconnect.py` — 12 passed:
  - `_try_get_redis_pids`: all-success, partial-fail, all-fail, empty-list, missing-`process_id` field.
  - `_reconnect_ssh_tunnel_and_redis`: missing-param guard (parametrized over each required field), happy path verifying arg order to `ssh_tunnel_redisconn` and in-place mutation of `setup_details["env"]`, swallowed `old_tunnel.stop()` failure, and no-prior-tunnel case.
- [ ] End-to-end: trigger a long read-only reuse run on a real EC2 setup and confirm a forced tunnel kill triggers a successful reconnection (no automated coverage for this — relies on production validation).