### PR TITLE
compare: always apply arch filter when an architecture is set

### DIFF
--- a/redisbench_admin/compare/compare.py
+++ b/redisbench_admin/compare/compare.py
@@ -1386,7 +1386,13 @@ def from_rts_to_regression_table(
             filters_baseline.append("github_repo={}".format(tf_github_repo))
         if running_platform is not None:
             filters_baseline.append("running_platform={}".format(running_platform))
-        if baseline_architecture != ARCH_X86:
+        if baseline_architecture is not None:
+            # Always apply the arch filter, including for x86_64. Multiple
+            # architectures coexist under the same test_name in RTS (each
+            # series carries an explicit arch={x86_64,aarch64} label), so
+            # without this filter TS.QUERYINDEX returns both and the
+            # downstream "take the first one" fallback can silently
+            # cross-compare arches and produce fake regressions/improvements.
             filters_baseline.append(f"arch={baseline_architecture}")
         filters_comparison = [
             "{}={}".format(by_str_comparison, comparison_str),
@@ -1401,7 +1407,8 @@ def from_rts_to_regression_table(
             filters_comparison.append("github_repo={}".format(tf_github_repo))
         if running_platform is not None:
             filters_comparison.append("running_platform={}".format(running_platform))
-        if comparison_architecture != ARCH_X86:
+        if comparison_architecture is not None:
+            # See note above on filters_baseline.
             filters_comparison.append(f"arch={comparison_architecture}")
         baseline_timeseries = rts.ts().queryindex(filters_baseline)
         comparison_timeseries = rts.ts().queryindex(filters_comparison)
@@ -1933,9 +1940,10 @@ def check_client_side_latency(
             if running_platform is not None:
                 filters_baseline.append(f"running_platform={running_platform}")
                 filters_comparison.append(f"running_platform={running_platform}")
-            if baseline_architecture != ARCH_X86:
+            # Always apply arch filter (see note at the throughput-query site).
+            if baseline_architecture is not None:
                 filters_baseline.append(f"arch={baseline_architecture}")
-            if comparison_architecture != ARCH_X86:
+            if comparison_architecture is not None:
                 filters_comparison.append(f"arch={comparison_architecture}")
 
             # Query for client-side latency time-series
@@ -2207,9 +2215,10 @@ def perform_variance_and_p99_analysis(
         if running_platform is not None:
             filters_baseline.append(f"running_platform={running_platform}")
             filters_comparison.append(f"running_platform={running_platform}")
-        if baseline_architecture != ARCH_X86:
+        # Always apply arch filter (see note at the throughput-query site).
+        if baseline_architecture is not None:
             filters_baseline.append(f"arch={baseline_architecture}")
-        if comparison_architecture != ARCH_X86:
+        if comparison_architecture is not None:
             filters_comparison.append(f"arch={comparison_architecture}")
 
         # Query for p99 latency time-series
@@ -2495,9 +2504,10 @@ def check_latency_for_unstable_throughput(
         if running_platform is not None:
             filters_baseline.append(f"running_platform={running_platform}")
             filters_comparison.append(f"running_platform={running_platform}")
-        if baseline_architecture != ARCH_X86:
+        # Always apply arch filter (see note at the throughput-query site).
+        if baseline_architecture is not None:
             filters_baseline.append(f"arch={baseline_architecture}")
-        if comparison_architecture != ARCH_X86:
+        if comparison_architecture is not None:
             filters_comparison.append(f"arch={comparison_architecture}")
 
         # Query for p50 latency time-series


### PR DESCRIPTION
## Summary
- The four `TS.QUERYINDEX` filter-construction sites in `redisbench_admin/compare/compare.py` guarded the `arch={baseline,comparison}_architecture` filter with `!= ARCH_X86`, so the filter was only ever appended for non-x86_64 runs.
- Since both flags default to `ARCH` (= `x86_64`), the common case **x86_64-vs-x86_64 ran with no `arch=` filter at all**. `TS.QUERYINDEX` returned series for every architecture, and the downstream "take the first one" fallback could silently cross-compare arches between baseline and comparison sides.
- Replace the four `!= ARCH_X86` guards with `is not None` so the filter is always applied when an architecture is set.

## Concrete bug observed

Running:
```bash
redisbench-admin compare \
  --baseline-branch        bench/expire-persist-coverage \
  --comparison-branch      joan-expire-not-fully-reindex \
  --baseline_architecture  x86_64 \
  --comparison_architecture x86_64 \
  --testname_regex '^search-(expire|persist)-' \
  --last_n 5  --regressions-percent-lower-limit 12 \
  --metric_name "(Ops/sec,...)"
```

before the fix produced a confident-looking `-29.5%` regression on `search-expire-doc-json-10-milliseconds`:

| | Baseline (median ± std) | Comparison (median ± std) | Δ |
|---|---|---|---|
| **before fix** | `18 651 ± 1.8%` (x86_64 `Totals`) | `13 154 ± 0.7%` (**aarch64** `Totalsarch=aarch64`) | **−29.5%** ❌ |
| **after fix** | `18 651 ± 1.8%` (x86_64 `Totals`) | `17 982 ± 10.5%` (x86_64 `Totals`) | −3.6% (UNSTABLE — within noise) ✅ |

The `Baseline filters: [...]` log line now ends with `'arch=x86_64'`, and `Still multiple time-series after filtering, taking the first one` warnings drop from 20+ to 0 on the same workload.

## Sites changed
1. `from_rts_to_regression_table` — main throughput query (~L1389/1404)
2. `check_client_side_latency` — client-side latency query (~L1943)
3. `perform_variance_and_p99_analysis` — server-side p99 query (~L2218)
4. `check_latency_for_unstable_throughput` — p50 latency-confirmation query (~L2505)

## Compatibility note
This is technically a behaviour change: queries are now strict about `arch=`. Series in RTS that *don't* have an `arch=` label will no longer match a default-x86_64 query. From inspection on `benchmarks.redislabs.com:12000`, every series we looked at carries an explicit `arch={x86_64,aarch64}` label, so this should be a no-op for current data. If a project has older un-labeled series and needs them included, they'd need a separate negative-filter strategy (e.g. `arch!=aarch64`); that's out of scope here.

## Test plan
- [ ] Re-run the offending compare command above and confirm the JSON regression collapses from `-29.5%` to `-3.6% UNSTABLE`.
- [ ] Confirm `Baseline filters: [...]` log line now contains `'arch=x86_64'`.
- [ ] Confirm `Still multiple time-series after filtering, taking the first one` warning count drops to 0 on a workload that previously triggered it.
- [ ] (optional) Verify aarch64-vs-aarch64 mode still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)