### PR TITLE
add post_commands symmetric to init_commands to db_config.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.31"
+version = "0.12.32"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run/common.py
+++ b/redisbench_admin/run/common.py
@@ -570,122 +570,118 @@ def check_dbconfig_keyspacelen_requirement(
     return required, keyspacelen, keyspacelen_min
 
 
-def execute_init_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
+def _execute_dbconfig_commands(
+    benchmark_config,
+    r,
+    command_key,
+    log_label,
+    broadcast_ft_create,
+    dbconfig_keyname="dbconfig",
+):
+    """Execute a list of Redis commands declared under dbconfig.<command_key>.
+
+    Supports both dict-format (`dbconfig: {<command_key>: [...]}`) and the
+    legacy list-format (`dbconfig: [- <command_key>: [...]]`). Each command
+    may be a list (`["SET", "k", "v"]`) or a quoted-string form
+    (`'"SET" "k" "v"'`).
+
+    Returns the count of commands successfully sent. ConnectionError on a
+    given command is logged and the loop continues.
+
+    Parameters
+    ----------
+    command_key : str
+        The dbconfig sub-key to read commands from ("init_commands" or
+        "post_commands").
+    log_label : str
+        Human-readable label used in INFO log lines (e.g. "init command").
+    broadcast_ft_create : bool
+        If True, FT.CREATE is sent to all nodes via target_nodes="all" so it
+        works on OSS Cluster. Init-commands set this; post-commands do not
+        (preserved for backward compatibility).
+    """
     cmds = None
     res = 0
     if dbconfig_keyname in benchmark_config:
         dbconfig = benchmark_config[dbconfig_keyname]
         # Handle both dict and list formats
         if isinstance(dbconfig, dict):
-            # New format: dbconfig is a dict
-            if "init_commands" in dbconfig:
-                cmds = dbconfig["init_commands"]
+            if command_key in dbconfig:
+                cmds = dbconfig[command_key]
         elif isinstance(dbconfig, list):
-            # Old format: dbconfig is a list of dicts
             for k in dbconfig:
-                if isinstance(k, dict) and "init_commands" in k:
-                    cmds = k["init_commands"]
-    if cmds is not None:
-        for cmd in cmds:
-            is_array = False
-            if type(cmd) == list:
-                is_array = True
-            if '"' in cmd:
-                cols = []
-                for lines in csv.reader(
-                    cmd,
-                    quotechar='"',
-                    delimiter=" ",
-                    quoting=csv.QUOTE_ALL,
-                    skipinitialspace=True,
-                ):
-                    if lines[0] != " " and len(lines[0]) > 0:
-                        cols.append(lines[0])
-                cmd = cols
-                is_array = True
-            try:
-                logging.info("Sending init command: {}".format(cmd))
-                stdout = ""
-                if is_array:
-                    if "FT.CREATE" in cmd[0]:
-                        logging.info("Detected FT.CREATE to all nodes on OSS Cluster")
-                        try:
-                            stdout = r.execute_command(*cmd, target_nodes="all")
-                        except redis.exceptions.ResponseError:
-                            pass
+                if isinstance(k, dict) and command_key in k:
+                    cmds = k[command_key]
+    if cmds is None:
+        return res
+
+    for cmd in cmds:
+        is_array = False
+        if type(cmd) == list:
+            is_array = True
+        if '"' in cmd:
+            cols = []
+            for lines in csv.reader(
+                cmd,
+                quotechar='"',
+                delimiter=" ",
+                quoting=csv.QUOTE_ALL,
+                skipinitialspace=True,
+            ):
+                if lines[0] != " " and len(lines[0]) > 0:
+                    cols.append(lines[0])
+            cmd = cols
+            is_array = True
+        try:
+            logging.info("Sending {}: {}".format(log_label, cmd))
+            stdout = ""
+            verb = cmd[0] if is_array else cmd
+            if broadcast_ft_create and "FT.CREATE" in verb:
+                logging.info("Detected FT.CREATE to all nodes on OSS Cluster")
+                try:
+                    if is_array:
+                        stdout = r.execute_command(*cmd, target_nodes="all")
                     else:
-                        stdout = r.execute_command(*cmd)
-                else:
-                    if "FT.CREATE" in cmd:
-                        logging.info("Detected FT.CREATE to all nodes on OSS Cluster")
-                        try:
-                            stdout = r.execute_command(cmd, target_nodes="all")
-                        except redis.exceptions.ResponseError:
-                            pass
-                    else:
-                        stdout = r.execute_command(cmd)
-                res = res + 1
-                logging.info("Command reply: {}".format(stdout))
-            except redis.connection.ConnectionError as e:
-                logging.error(
-                    "Error establishing connection to Redis. Message: {}".format(
-                        e.__str__()
-                    )
-                )
-
-    return res
-
-
-def execute_post_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
-    cmds = None
-    res = 0
-    if dbconfig_keyname in benchmark_config:
-        dbconfig = benchmark_config[dbconfig_keyname]
-        # Handle both dict and list formats
-        if isinstance(dbconfig, dict):
-            # New format: dbconfig is a dict
-            if "post_commands" in dbconfig:
-                cmds = dbconfig["post_commands"]
-        elif isinstance(dbconfig, list):
-            # Old format: dbconfig is a list of dicts
-            for k in dbconfig:
-                if isinstance(k, dict) and "post_commands" in k:
-                    cmds = k["post_commands"]
-    if cmds is not None:
-        for cmd in cmds:
-            is_array = False
-            if type(cmd) == list:
-                is_array = True
-            if '"' in cmd:
-                cols = []
-                for lines in csv.reader(
-                    cmd,
-                    quotechar='"',
-                    delimiter=" ",
-                    quoting=csv.QUOTE_ALL,
-                    skipinitialspace=True,
-                ):
-                    if lines[0] != " " and len(lines[0]) > 0:
-                        cols.append(lines[0])
-                cmd = cols
-                is_array = True
-            try:
-                logging.info("Sending post command: {}".format(cmd))
-                stdout = ""
+                        stdout = r.execute_command(cmd, target_nodes="all")
+                except redis.exceptions.ResponseError:
+                    pass
+            else:
                 if is_array:
                     stdout = r.execute_command(*cmd)
                 else:
                     stdout = r.execute_command(cmd)
-                res = res + 1
-                logging.info("Command reply: {}".format(stdout))
-            except redis.connection.ConnectionError as e:
-                logging.error(
-                    "Error establishing connection to Redis. Message: {}".format(
-                        e.__str__()
-                    )
+            res = res + 1
+            logging.info("Command reply: {}".format(stdout))
+        except redis.connection.ConnectionError as e:
+            logging.error(
+                "Error establishing connection to Redis. Message: {}".format(
+                    e.__str__()
                 )
+            )
 
     return res
+
+
+def execute_init_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
+    return _execute_dbconfig_commands(
+        benchmark_config,
+        r,
+        command_key="init_commands",
+        log_label="init command",
+        broadcast_ft_create=True,
+        dbconfig_keyname=dbconfig_keyname,
+    )
+
+
+def execute_post_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
+    return _execute_dbconfig_commands(
+        benchmark_config,
+        r,
+        command_key="post_commands",
+        log_label="post command",
+        broadcast_ft_create=False,
+        dbconfig_keyname=dbconfig_keyname,
+    )
 
 
 def extract_test_feasible_setups(

--- a/redisbench_admin/run/common.py
+++ b/redisbench_admin/run/common.py
@@ -636,6 +636,58 @@ def execute_init_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
     return res
 
 
+def execute_post_commands(benchmark_config, r, dbconfig_keyname="dbconfig"):
+    cmds = None
+    res = 0
+    if dbconfig_keyname in benchmark_config:
+        dbconfig = benchmark_config[dbconfig_keyname]
+        # Handle both dict and list formats
+        if isinstance(dbconfig, dict):
+            # New format: dbconfig is a dict
+            if "post_commands" in dbconfig:
+                cmds = dbconfig["post_commands"]
+        elif isinstance(dbconfig, list):
+            # Old format: dbconfig is a list of dicts
+            for k in dbconfig:
+                if isinstance(k, dict) and "post_commands" in k:
+                    cmds = k["post_commands"]
+    if cmds is not None:
+        for cmd in cmds:
+            is_array = False
+            if type(cmd) == list:
+                is_array = True
+            if '"' in cmd:
+                cols = []
+                for lines in csv.reader(
+                    cmd,
+                    quotechar='"',
+                    delimiter=" ",
+                    quoting=csv.QUOTE_ALL,
+                    skipinitialspace=True,
+                ):
+                    if lines[0] != " " and len(lines[0]) > 0:
+                        cols.append(lines[0])
+                cmd = cols
+                is_array = True
+            try:
+                logging.info("Sending post command: {}".format(cmd))
+                stdout = ""
+                if is_array:
+                    stdout = r.execute_command(*cmd)
+                else:
+                    stdout = r.execute_command(cmd)
+                res = res + 1
+                logging.info("Command reply: {}".format(stdout))
+            except redis.connection.ConnectionError as e:
+                logging.error(
+                    "Error establishing connection to Redis. Message: {}".format(
+                        e.__str__()
+                    )
+                )
+
+    return res
+
+
 def extract_test_feasible_setups(
     benchmark_config, param, default_specs, backwards_compatible=True
 ):
@@ -788,6 +840,20 @@ def run_redis_pre_steps(benchmark_config, r, required_modules):
         version = r.info("server")["redis_version"]
 
     return version
+
+
+def run_redis_post_steps(benchmark_config, r):
+    logging.info("Running post commands after benchmark completes.")
+    execute_post_commands_start_time = datetime.datetime.now()
+    execute_post_commands(benchmark_config, r)
+    execute_post_commands_duration_seconds = (
+        datetime.datetime.now() - execute_post_commands_start_time
+    ).seconds
+    logging.info(
+        "Running post commands took {} secs.".format(
+            execute_post_commands_duration_seconds
+        )
+    )
 
 
 def search_specific_init(r, module_names):

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -535,12 +535,6 @@ def run_local_command_logic(args, project_name, project_version):
                                         benchmark_end_time, benchmark_start_time
                                     )
                                 )
-                                # run post commands after benchmark completes
-                                if args.dry_run is False:
-                                    for redis_conn in redis_conns:
-                                        run_redis_post_steps(
-                                            benchmark_config, redis_conn
-                                        )
                                 if args.dry_run is False:
                                     logging.info("Extracting the benchmark results")
                                     logging.info("stdout: {}".format(stdout))
@@ -579,6 +573,15 @@ def run_local_command_logic(args, project_name, project_version):
                                         ]
                                     },
                                 )
+
+                                # run post commands after benchmark completes and
+                                # end-of-benchmark metrics have been collected, so
+                                # post_commands cannot mutate measured state
+                                if args.dry_run is False:
+                                    for redis_conn in redis_conns:
+                                        run_redis_post_steps(
+                                            benchmark_config, redis_conn
+                                        )
 
                                 if (
                                     profilers_enabled

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -35,6 +35,7 @@ from redisbench_admin.run.common import (
     get_setup_type_and_primaries_count,
     dso_check,
     print_results_table_stdout,
+    run_redis_post_steps,
 )
 from redisbench_admin.run.metrics import (
     from_info_to_overall_shard_cpu,
@@ -534,6 +535,12 @@ def run_local_command_logic(args, project_name, project_version):
                                         benchmark_end_time, benchmark_start_time
                                     )
                                 )
+                                # run post commands after benchmark completes
+                                if args.dry_run is False:
+                                    for redis_conn in redis_conns:
+                                        run_redis_post_steps(
+                                            benchmark_config, redis_conn
+                                        )
                                 if args.dry_run is False:
                                     logging.info("Extracting the benchmark results")
                                     logging.info("stdout: {}".format(stdout))

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -1032,12 +1032,6 @@ def run_remote_command_logic(args, project_name, project_version):
                                         architecture,
                                     )
 
-                                    # run post commands after benchmark completes
-                                    for redis_conn in redis_conns:
-                                        run_redis_post_steps(
-                                            benchmark_config, redis_conn
-                                        )
-
                                     # --- parca-agent per-test label cleanup ---
                                     # Clear metadata-external-labels so a
                                     # subsequent test doesn't inherit stale
@@ -1379,6 +1373,16 @@ def run_remote_command_logic(args, project_name, project_version):
                                                     "The benchmark ran successfully but the post-benchmark metrics export failed: {}".format(
                                                         test_name, e
                                                     )
+                                                )
+
+                                        # run post commands after benchmark completes and
+                                        # end-of-benchmark metrics have been collected and
+                                        # exported, so post_commands cannot mutate the
+                                        # measured state (used_memory, commandstats, etc.)
+                                        if args.dry_run is False:
+                                            for redis_conn in redis_conns:
+                                                run_redis_post_steps(
+                                                    benchmark_config, redis_conn
                                                 )
 
                                         # Check if environment is saved in shared_env for reuse

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -31,6 +31,7 @@ from redisbench_admin.run.common import (
     get_setup_type_and_primaries_count,
     common_properties_log,
     print_results_table_stdout,
+    run_redis_post_steps,
 )
 from redisbench_admin.run.git import git_vars_crosscheck
 from redisbench_admin.run.grafana import generate_artifacts_table_grafana_redis
@@ -1030,6 +1031,12 @@ def run_remote_command_logic(args, project_name, project_version):
                                         redis_password,
                                         architecture,
                                     )
+
+                                    # run post commands after benchmark completes
+                                    for redis_conn in redis_conns:
+                                        run_redis_post_steps(
+                                            benchmark_config, redis_conn
+                                        )
 
                                     # --- parca-agent per-test label cleanup ---
                                     # Clear metadata-external-labels so a

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -25,6 +25,7 @@ from redisbench_admin.run.common import (
     dbconfig_keyspacelen_check,
     common_properties_log,
     execute_init_commands,
+    execute_post_commands,
     extract_input_file_url_from_parameters,
 )
 from redisbench_admin.run_remote.args import create_run_remote_arguments
@@ -631,7 +632,7 @@ def test_common_properties_log():
     )
 
 
-def test_execute_init_commands():
+def test_execute_init_and_post_commands():
     from redis import StrictRedis
     from redis.exceptions import ConnectionError
 
@@ -655,6 +656,15 @@ def test_execute_init_commands():
 
         assert b"key" in redis.keys()
         assert b"key2" in redis.keys()
+
+        # now test post_commands (array, simple array, and quoted string)
+        total_post_cmds = execute_post_commands(benchmark_config, redis)
+        assert total_post_cmds == 3
+        assert b"post_key" in redis.keys()
+        # key should have been deleted by the DEL post_command
+        assert b"key" not in redis.keys()
+        # quoted string form: "HSET" "post_key2" "FIELD" "VAL"
+        assert b"post_key2" in redis.keys()
     except ConnectionError:
         pass
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -665,6 +665,28 @@ def test_execute_init_and_post_commands():
         assert b"key" not in redis.keys()
         # quoted string form: "HSET" "post_key2" "FIELD" "VAL"
         assert b"post_key2" in redis.keys()
+
+        # missing post_commands → graceful no-op, returns 0
+        empty_config = {"dbconfig": [{"init_commands": [["SET", "x", "1"]]}]}
+        assert execute_post_commands(empty_config, redis) == 0
+
+        # dict-format dbconfig (alternate to list-format) — exercises the
+        # `isinstance(dbconfig, dict)` branch
+        redis.flushall()
+        dict_config = {
+            "dbconfig": {
+                "post_commands": [
+                    ["SET", "dict_post_key", "v"],
+                    ["SET", "dict_post_key2", "v"],
+                ]
+            }
+        }
+        assert execute_post_commands(dict_config, redis) == 2
+        assert b"dict_post_key" in redis.keys()
+        assert b"dict_post_key2" in redis.keys()
+
+        # absent dbconfig altogether → graceful no-op
+        assert execute_post_commands({}, redis) == 0
     except ConnectionError:
         pass
 

--- a/tests/test_data/init-commands-array.yml
+++ b/tests/test_data/init-commands-array.yml
@@ -8,3 +8,7 @@ dbconfig:
   - ["SCRIPT", "LOAD" ,"redis.call('hset', 'h1', 'k', 'v');redis.call('hset', 'h2', 'k', 'v');redis.call('expire', 'h1', 3600);redis.call('expire', 'h2', 3600);return redis.call('ping')"]
   - ["SET", "key", "val"]
   - '"HSET" "key2" "FIELD" "VAL"'
+- post_commands:
+  - ["SET", "post_key", "post_val"]
+  - ["DEL", "key"]
+  - '"HSET" "post_key2" "FIELD" "VAL"'

--- a/tests/test_run_remote_reconnect.py
+++ b/tests/test_run_remote_reconnect.py
@@ -122,13 +122,13 @@ def test_reconnect_happy_path_updates_env_and_returns_new_conn_and_tunnel():
 
     # ssh_tunnel_redisconn called with the params from env, in the expected order.
     mocked_setup.assert_called_once_with(
-        6379,           # server_plaintext_port
-        "10.0.0.5",     # server_private_ip
-        "1.2.3.4",      # server_public_ip
-        "ubuntu",       # username
-        22,             # db_ssh_port
-        "/tmp/key.pem", # private_key
-        "secret",       # redis_password
+        6379,  # server_plaintext_port
+        "10.0.0.5",  # server_private_ip
+        "1.2.3.4",  # server_public_ip
+        "ubuntu",  # username
+        22,  # db_ssh_port
+        "/tmp/key.pem",  # private_key
+        "secret",  # redis_password
     )
 
     # Return values


### PR DESCRIPTION
## Summary

Adds a `post_commands` block to `dbconfig` (symmetric to the existing `init_commands`) so spec authors can declare Redis commands to run **after** a benchmark completes — useful for cleanup, validation, or post-test state extraction without tampering with what the benchmark measured.

```yaml
dbconfig:
  - init_commands:
      - ["FT.CREATE", "idx", ...]
  - post_commands:
      - ["FT.DROPINDEX", "idx"]
      - ["FLUSHDB"]
```

Wired into both `run-local` and `run-remote`.

## Ordering guarantee

`post_commands` run **after** end-of-benchmark metric collection and export:

```
benchmark client exits
  → profiler stop / CPU stats finalized
  → collect_redis_metrics(["memory"]) → used_memory, used_memory_dataset
  → collect_redis_metrics(["commandstats", "latencystats"])
  → export_redis_metrics(...) to RedisTimeSeries
  → post_commands ← here
  → environment teardown
```

This ordering matters: post_commands that mutate the dataset (e.g. `FLUSHDB`, `DEL`, `DEBUG RELOAD`, `MEMORY PURGE`) cannot corrupt the `used_memory` / `commandstats` / `latencystats` series pushed to RTS.

`post_commands` are skipped under `--dry-run` in both `run-local` and `run-remote`.

## Test plan

- [x] `tests/test_common.py::test_execute_init_and_post_commands` — passes against the tox `rts_datasink` Redis container. Covers:
  - Three command shapes (list, simple list, quoted string) on list-format `dbconfig`
  - Order vs `init_commands` (asserted via a `DEL` post_command removing an init key)
  - Missing `post_commands` key → graceful no-op, returns `0`
  - Dict-format `dbconfig` (alternate to list-format) → exercises the `isinstance(dbconfig, dict)` branch
  - Absent `dbconfig` → graceful no-op
- [x] Bumped version to `0.12.32`.