### PR TITLE
ci: bump Node-20-deprecated actions across all workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,14 +10,12 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-
-    - uses: docker-practice/actions-setup-docker@master
 
     - name: Install Poetry
       run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: "ubuntu-latest"
     name: os ${{ matrix.os }} python ${{ matrix.python-version }} Linting, testing, and compliance
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -63,7 +63,7 @@ jobs:
         tox
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v5
       if: contains(env.USING_COVERAGE, matrix.python-version)
       with:
         token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
## Summary

GitHub is forcing all Node.js-20 actions onto Node.js 24 by default starting **June 2nd 2026**, and Node.js 20 is removed from the runners on **September 16th 2026**. All three workflow files in this repo currently use Node-20-pinned actions, so any release cut, PR run, or scheduled scan after the cutoffs is at risk of breaking.

This was first surfaced in the v0.12.32 publish run (PR #539): the Publish workflow emitted the deprecation warning on every step. Same root cause applies to `tox.yml` (PR + push CI) and `codeql.yml` (security scan).

## Changes

### `.github/workflows/publish-pypi.yml`
- `actions/checkout@master` → `@v4`
- `actions/setup-python@v1` → `@v5`
- Drop `docker-practice/actions-setup-docker@master` — also Node-20-pinned, and **unused**: the publish step only runs `poetry publish`, no Docker daemon required. The `docker` / `tox-docker` Python packages pulled via `dev_requirements.txt` are just Python clients and pip-install fine without it.

### `.github/workflows/tox.yml`
- `actions/checkout@master` → `@v4`
- `actions/setup-python@v1` → `@v5`
- `codecov/codecov-action@v2` → `@v5`

### `.github/workflows/codeql.yml`
- `actions/checkout@v3` → `@v4`
- `github/codeql-action/{init,autobuild,analyze}@v2` → `@v3`

Behavior unchanged across all three: same Python versions, same poetry install + publish path, same codecov token usage, same CodeQL queries.

## Test plan

- [ ] `tox.yml` runs on this PR — confirm all 4 Python matrix jobs (3.11–3.14) pass with no Node-20 deprecation warnings.
- [ ] `codeql.yml` runs on this PR — confirm the analyze step succeeds with no Node-20 warnings.
- [ ] After merge: cut a `v0.12.33` release tag and confirm the publish workflow runs cleanly with no Node-20 warnings (the original symptom from PR #539's release run).

## Out of scope (none)

All workflow files in `.github/workflows/` are covered. Nothing left for a follow-up.