### PR TITLE
fix cleaning mixed tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.32"
+version = "0.12.33"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -328,6 +328,12 @@ def run_local_command_logic(args, project_name, project_version):
                                         # Save to shared storage for cross-benchmark-type reuse
                                         if reuse_mixed:
                                             shared_env[env_key] = setup_details["env"]
+                                            # Mixed tests must not share env with the next
+                                            # mixed test in this group — state is dirty.
+                                            # shared_env keeps the env alive for a subsequent
+                                            # read-only group on this (setup, dataset).
+                                            if benchmark_type == "mixed":
+                                                setup_details["env"] = None
                                 else:
                                     logging.info(
                                         f"Reusing environment from previous benchmark for dataset reuse (dataset: {dataset_name}, setup: {setup_name})."

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -326,14 +326,13 @@ def run_local_command_logic(args, project_name, project_version):
                                             ],
                                         )
                                         # Save to shared storage for cross-benchmark-type reuse
-                                        if reuse_mixed:
-                                            shared_env[env_key] = setup_details["env"]
-                                            # Mixed tests must not share env with the next
-                                            # mixed test in this group — state is dirty.
-                                            # shared_env keeps the env alive for a subsequent
-                                            # read-only group on this (setup, dataset).
-                                            if benchmark_type == "mixed":
-                                                setup_details["env"] = None
+                                        save_env_for_cross_type_reuse(
+                                            benchmark_type,
+                                            reuse_mixed,
+                                            env_key,
+                                            setup_details,
+                                            shared_env,
+                                        )
                                 else:
                                     logging.info(
                                         f"Reusing environment from previous benchmark for dataset reuse (dataset: {dataset_name}, setup: {setup_name})."
@@ -771,6 +770,31 @@ def run_local_command_logic(args, project_name, project_version):
     # Log environment reuse summary
     env_tracker.log_summary_table()
     exit(return_code)
+
+
+def save_env_for_cross_type_reuse(
+    benchmark_type,
+    reuse_mixed,
+    env_key,
+    setup_details,
+    shared_env,
+):
+    """For a freshly-spun-up benchmark with `reuse_mixed=True`, publish the env
+    to `shared_env` so a subsequent group on the same `(setup, dataset)` can
+    reuse it. For `mixed` only, also clear `setup_details["env"]` so the next
+    mixed test in the *current* group gets its own fresh spin-up.
+
+    Returns True if the publish happened, False otherwise.
+
+    `mixed` semantically forbids env reuse within a group — without the clear,
+    the next iteration takes the reuse branch with a dirty env.
+    """
+    if not reuse_mixed:
+        return False
+    shared_env[env_key] = setup_details["env"]
+    if benchmark_type == "mixed":
+        setup_details["env"] = None
+    return True
 
 
 def teardown_local_setup(redis_conns, redis_processes, setup_name):

--- a/redisbench_admin/run_local/run_local.py
+++ b/redisbench_admin/run_local/run_local.py
@@ -245,6 +245,18 @@ def run_local_command_logic(args, project_name, project_version):
                         if setup_type in args.allowed_envs:
                             redis_processes = []
                             redis_conns = []
+                            # Mixed groups: tear down the previous test's env so
+                            # each mixed test gets a fresh spin-up. No-op on the
+                            # first iteration (env is None) and for read-only
+                            # types (which intentionally reuse within a group).
+                            tear_down_previous_mixed_env_if_needed(
+                                benchmark_type,
+                                reuse_mixed,
+                                setup_details,
+                                shared_env,
+                                env_key,
+                                args.keep_env_and_topo,
+                            )
                             # after we've spinned Redis, even on error we should always teardown
                             # in case of some unexpected error we fail the test
                             # noinspection PyBroadException
@@ -327,7 +339,6 @@ def run_local_command_logic(args, project_name, project_version):
                                         )
                                         # Save to shared storage for cross-benchmark-type reuse
                                         save_env_for_cross_type_reuse(
-                                            benchmark_type,
                                             reuse_mixed,
                                             env_key,
                                             setup_details,
@@ -773,27 +784,65 @@ def run_local_command_logic(args, project_name, project_version):
 
 
 def save_env_for_cross_type_reuse(
-    benchmark_type,
     reuse_mixed,
     env_key,
     setup_details,
     shared_env,
 ):
-    """For a freshly-spun-up benchmark with `reuse_mixed=True`, publish the env
-    to `shared_env` so a subsequent group on the same `(setup, dataset)` can
-    reuse it. For `mixed` only, also clear `setup_details["env"]` so the next
-    mixed test in the *current* group gets its own fresh spin-up.
+    """When `reuse_mixed=True`, publish a freshly-spun-up benchmark's env to
+    `shared_env` so a subsequent group on the same `(setup, dataset)` can
+    reuse it via the cross-type handoff.
 
     Returns True if the publish happened, False otherwise.
-
-    `mixed` semantically forbids env reuse within a group — without the clear,
-    the next iteration takes the reuse branch with a dirty env.
     """
     if not reuse_mixed:
         return False
     shared_env[env_key] = setup_details["env"]
-    if benchmark_type == "mixed":
-        setup_details["env"] = None
+    return True
+
+
+def tear_down_previous_mixed_env_if_needed(
+    benchmark_type,
+    reuse_mixed,
+    setup_details,
+    shared_env,
+    env_key,
+    keep_env_and_topo,
+):
+    """Pre-iteration cleanup for mixed groups: tear down the env left populated
+    by the previous iteration so this test gets a fresh spin-up.
+
+    `mixed` semantically requires each test to run against a fresh Redis env.
+    The cross-type-reuse optimization keeps the env alive across iterations
+    (via `shared_env`) so a subsequent read-only group can inherit it, but
+    that means the env from the previous mixed test would otherwise leak into
+    the next mixed test — the dispatcher would take the reuse branch and
+    `ro_benchmark_reuse` would assert `benchmark_type == "read-only"`.
+
+    The last mixed test's env still survives at end-of-group (because this
+    helper is a no-op on the FIRST iteration: env is None), and the end-of-
+    group logic preserves it in `shared_env` for the cross-type handoff.
+
+    No-op for non-mixed types (read-only intentionally reuses within a group),
+    for the first iteration in a group (env is None), and when
+    `keep_env_and_topo` is True (user opted out of teardown).
+
+    Returns True if a teardown happened, False otherwise.
+    """
+    if benchmark_type != "mixed" or not reuse_mixed:
+        return False
+    if setup_details["env"] is None:
+        return False
+    if keep_env_and_topo:
+        return False
+
+    old_env = setup_details["env"]
+    teardown_local_setup(
+        old_env["redis_conns"], old_env["redis_processes"], "previous-mixed"
+    )
+    if shared_env.get(env_key) is old_env:
+        del shared_env[env_key]
+    setup_details["env"] = None
     return True
 
 

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -768,6 +768,11 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 shared_env[env_key] = setup_details[
                                                     "env"
                                                 ]
+                                                # Mixed tests must not share env with the next
+                                                # mixed test in this group — state is dirty.
+                                                # shared_env keeps the env alive for a subsequent
+                                                # read-only group on this (setup, dataset).
+                                                setup_details["env"] = None
                                                 logging.info(
                                                     f"Saved environment to shared_env for dataset '{dataset_name}' and setup '{setup_name}'"
                                                 )

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -760,19 +760,14 @@ def run_remote_command_logic(args, project_name, project_version):
                                                 ]
                                             # If this is a mixed benchmark and we're reusing,
                                             # save to shared_env for cross-benchmark-type reuse
-                                            if (
-                                                benchmark_type == "mixed"
-                                                and reuse_mixed
+                                            if save_env_for_cross_type_reuse(
+                                                benchmark_type,
+                                                reuse_mixed,
+                                                dataset_name,
+                                                setup_name,
+                                                setup_details,
+                                                shared_env,
                                             ):
-                                                env_key = (dataset_name, setup_name)
-                                                shared_env[env_key] = setup_details[
-                                                    "env"
-                                                ]
-                                                # Mixed tests must not share env with the next
-                                                # mixed test in this group — state is dirty.
-                                                # shared_env keeps the env alive for a subsequent
-                                                # read-only group on this (setup, dataset).
-                                                setup_details["env"] = None
                                                 logging.info(
                                                     f"Saved environment to shared_env for dataset '{dataset_name}' and setup '{setup_name}'"
                                                 )
@@ -1978,6 +1973,33 @@ def ro_benchmark_reuse(
         pids_match,
         remote_temporary_dir,
     )
+
+
+def save_env_for_cross_type_reuse(
+    benchmark_type,
+    reuse_mixed,
+    dataset_name,
+    setup_name,
+    setup_details,
+    shared_env,
+):
+    """For a freshly-spun-up `mixed` benchmark with `reuse_mixed=True`, publish
+    the env to `shared_env` so a subsequent read-only group on the same
+    `(setup, dataset)` can reuse it, then clear `setup_details["env"]` so the
+    next mixed test in the *current* group gets its own fresh spin-up.
+
+    Returns True if the publish happened, False otherwise.
+
+    `mixed` semantically forbids env reuse within a group — without the clear,
+    the next iteration takes the `ro_benchmark_reuse` branch and asserts on
+    `benchmark_type == "read-only"`.
+    """
+    if not (benchmark_type == "mixed" and reuse_mixed):
+        return False
+    env_key = (dataset_name, setup_name)
+    shared_env[env_key] = setup_details["env"]
+    setup_details["env"] = None
+    return True
 
 
 def ro_benchmark_set(

--- a/redisbench_admin/run_remote/run_remote.py
+++ b/redisbench_admin/run_remote/run_remote.py
@@ -597,6 +597,21 @@ def run_remote_command_logic(args, project_name, project_version):
                                     architecture,
                                 )
 
+                                # Mixed groups: tear down the previous test's
+                                # env so each mixed test gets a fresh spin-up.
+                                # No-op on the first iteration (env is None) and
+                                # for read-only types (which intentionally reuse
+                                # within a group).
+                                tear_down_previous_mixed_env_if_needed(
+                                    benchmark_type,
+                                    reuse_mixed,
+                                    setup_details,
+                                    shared_env,
+                                    (dataset_name, setup_name),
+                                    args.keep_env_and_topo,
+                                    skip_remote_db_setup,
+                                )
+
                                 # after we've created the env, even on error we should always teardown
                                 # in case of some unexpected error we fail the test
                                 try:
@@ -1985,19 +2000,64 @@ def save_env_for_cross_type_reuse(
 ):
     """For a freshly-spun-up `mixed` benchmark with `reuse_mixed=True`, publish
     the env to `shared_env` so a subsequent read-only group on the same
-    `(setup, dataset)` can reuse it, then clear `setup_details["env"]` so the
-    next mixed test in the *current* group gets its own fresh spin-up.
+    `(setup, dataset)` can reuse it via the cross-type handoff.
 
     Returns True if the publish happened, False otherwise.
-
-    `mixed` semantically forbids env reuse within a group — without the clear,
-    the next iteration takes the `ro_benchmark_reuse` branch and asserts on
-    `benchmark_type == "read-only"`.
     """
     if not (benchmark_type == "mixed" and reuse_mixed):
         return False
     env_key = (dataset_name, setup_name)
     shared_env[env_key] = setup_details["env"]
+    return True
+
+
+def tear_down_previous_mixed_env_if_needed(
+    benchmark_type,
+    reuse_mixed,
+    setup_details,
+    shared_env,
+    env_key,
+    keep_env_and_topo,
+    skip_remote_db_setup,
+):
+    """Pre-iteration cleanup for mixed groups: tear down the env left populated
+    by the previous iteration so this test gets a fresh spin-up.
+
+    `mixed` semantically requires each test to run against a fresh Redis env.
+    The cross-type-reuse optimization keeps the env alive across iterations
+    (via `shared_env`) so a subsequent read-only group can inherit it, but
+    that means the env from the previous mixed test would otherwise leak into
+    the next mixed test — the dispatcher would take the reuse branch and
+    `ro_benchmark_reuse` would assert `benchmark_type == "read-only"`.
+
+    The last mixed test's env still survives at end-of-group (because this
+    helper is a no-op on the FIRST iteration: env is None), and the end-of-
+    group logic preserves it in `shared_env` for the cross-type handoff.
+
+    No-op for non-mixed types (read-only intentionally reuses within a group),
+    for the first iteration in a group (env is None), when `keep_env_and_topo`
+    is True (user opted out of teardown), or when `skip_remote_db_setup` is
+    True.
+
+    Returns True if a teardown happened, False otherwise.
+    """
+    if benchmark_type != "mixed" or not reuse_mixed:
+        return False
+    if setup_details["env"] is None:
+        return False
+    if keep_env_and_topo or skip_remote_db_setup:
+        return False
+
+    old_env = setup_details["env"]
+    try:
+        shutdown_remote_redis(old_env["redis_conns"], old_env["ssh_tunnel"])
+    except Exception as e:
+        logging.warning(
+            f"Best-effort teardown of previous mixed env failed: {e!r}. "
+            "Continuing to spin up fresh for the next mixed test."
+        )
+    if shared_env.get(env_key) is old_env:
+        del shared_env[env_key]
     setup_details["env"] = None
     return True
 

--- a/tests/test_data/mixed_env_leak/mixed-load.yml
+++ b/tests/test_data/mixed_env_leak/mixed-load.yml
@@ -1,0 +1,17 @@
+
+name: "mixed-env-leak-load"
+setups:
+  - oss-standalone
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+# First of two `mixed` benchmarks sharing the same (setup, dataset_name).
+# Together with mixed-load2.yml and read-query.yml in the same glob, this
+# reproduces the bug where the second mixed test inherited the first one's
+# Redis env and was routed through ro_benchmark_reuse, which asserts on
+# benchmark_type == "read-only".
+clientconfig:
+  benchmark_type: "mixed"
+  dataset_name: "mixed-env-leak"
+  tool: memtier_benchmark
+  arguments: "--ratio 1:0 --key-maximum 1000 --key-minimum 1 --key-pattern P:P -d 1 -n allkeys --hide-histogram"

--- a/tests/test_data/mixed_env_leak/mixed-load2.yml
+++ b/tests/test_data/mixed_env_leak/mixed-load2.yml
@@ -1,0 +1,16 @@
+
+name: "mixed-env-leak-load2"
+setups:
+  - oss-standalone
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+# Second of two `mixed` benchmarks sharing (setup="oss-standalone",
+# dataset_name="mixed-env-leak"). Pre-fix, running this after mixed-load.yml
+# crashed on `assert benchmark_type == "read-only"` inside ro_benchmark_reuse,
+# because setup_details["env"] was left populated by the first mixed test.
+clientconfig:
+  benchmark_type: "mixed"
+  dataset_name: "mixed-env-leak"
+  tool: memtier_benchmark
+  arguments: "--ratio 1:0 --key-maximum 1000 --key-minimum 1 --key-pattern P:P -d 1 -n allkeys --hide-histogram"

--- a/tests/test_data/mixed_env_leak/read-query.yml
+++ b/tests/test_data/mixed_env_leak/read-query.yml
@@ -1,0 +1,22 @@
+
+name: "mixed-env-leak-query"
+setups:
+  - oss-standalone
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5
+# Read-only benchmark on the same dataset. Its presence in the plan is what
+# flips `reuse_mixed` to True (the optimization that triggers the bug path).
+# After the fix, this test also exercises the cross-type handoff: it inherits
+# the Redis env spun up by the last mixed-load*.yml via shared_env.
+dbconfig:
+  tool: memtier_benchmark
+  dataset_name: "mixed-env-leak"
+  arguments: "--ratio 1:0 --key-maximum 1000 --key-minimum 1 --key-pattern P:P -d 1 -n allkeys --hide-histogram"
+  check:
+   keyspacelen: 1000
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "-d 100 --ratio 0:1 --test-time 2 --pipeline 15 --key-pattern=P:P -t 2 --hide-histogram --key-maximum=1000 --key-minimum 1"

--- a/tests/test_run_local.py
+++ b/tests/test_run_local.py
@@ -13,6 +13,7 @@ from redisbench_admin.run_local.local_helpers import (
 from redisbench_admin.profilers.profilers_schema import get_profilers_rts_key_prefix
 from redisbench_admin.run_local.run_local import (
     run_local_command_logic,
+    save_env_for_cross_type_reuse,
 )
 from redisbench_admin.run.redistimeseries import datasink_profile_tabular_data
 from redisbench_admin.utils.local import get_local_run_full_filename
@@ -365,3 +366,77 @@ def test_run_local_dataset_reuse_ftsb():
         run_local_command_logic(args, "tool", "v0")
     except SystemExit as e:
         assert e.code == 0
+
+
+def test_save_env_for_cross_type_reuse_mixed_clears_setup_details():
+    """Regression for the `mixed -> mixed` env-leak bug.
+
+    Two mixed tests sharing `(setup, dataset)` with `reuse_mixed=True` must NOT
+    share an env: the contract of `mixed` is that each test gets a fresh
+    spin-up. Before the fix, `setup_details["env"]` was left populated after
+    the first mixed test and the dispatcher took the reuse branch on the
+    second one.
+
+    Invariant: after publishing the mixed env to `shared_env`,
+    `setup_details["env"]` must be cleared so the next iteration re-enters the
+    spin-up branch (`if setup_details["env"] is None`).
+    """
+    fake_env = {"redis_pids": [1234], "redis_conns": []}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+    env_key = ("ds1", "oss-standalone")
+
+    published = save_env_for_cross_type_reuse(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        env_key=env_key,
+        setup_details=setup_details,
+        shared_env=shared_env,
+    )
+
+    assert published is True
+    assert setup_details["env"] is None
+    assert shared_env[env_key] is fake_env
+
+
+def test_save_env_for_cross_type_reuse_read_only_keeps_setup_details():
+    """In run_local, `reuse_mixed=True` publishes for read-only too, so a
+    subsequent group on the same `(setup, dataset)` can pick the env up. But
+    `setup_details["env"]` must NOT be cleared: read-only's contract is that
+    state is pure and the env can (and should) be reused within the group."""
+    fake_env = {"redis_pids": [1234], "redis_conns": []}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+    env_key = ("ds1", "oss-standalone")
+
+    published = save_env_for_cross_type_reuse(
+        benchmark_type="read-only",
+        reuse_mixed=True,
+        env_key=env_key,
+        setup_details=setup_details,
+        shared_env=shared_env,
+    )
+
+    assert published is True
+    assert setup_details["env"] is fake_env
+    assert shared_env[env_key] is fake_env
+
+
+def test_save_env_for_cross_type_reuse_disabled_is_noop():
+    """When `reuse_mixed` is False, neither publish nor clear happens."""
+    fake_env = {"redis_pids": [1234], "redis_conns": []}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+    env_key = ("ds1", "oss-standalone")
+
+    published = save_env_for_cross_type_reuse(
+        benchmark_type="mixed",
+        reuse_mixed=False,
+        env_key=env_key,
+        setup_details=setup_details,
+        shared_env=shared_env,
+    )
+
+    assert published is False
+    assert setup_details["env"] is fake_env
+    assert shared_env == {}

--- a/tests/test_run_local.py
+++ b/tests/test_run_local.py
@@ -14,6 +14,7 @@ from redisbench_admin.profilers.profilers_schema import get_profilers_rts_key_pr
 from redisbench_admin.run_local.run_local import (
     run_local_command_logic,
     save_env_for_cross_type_reuse,
+    tear_down_previous_mixed_env_if_needed,
 )
 from redisbench_admin.run.redistimeseries import datasink_profile_tabular_data
 from redisbench_admin.utils.local import get_local_run_full_filename
@@ -407,26 +408,16 @@ def test_run_local_dataset_reuse_ftsb():
         assert e.code == 0
 
 
-def test_save_env_for_cross_type_reuse_mixed_clears_setup_details():
-    """Regression for the `mixed -> mixed` env-leak bug.
-
-    Two mixed tests sharing `(setup, dataset)` with `reuse_mixed=True` must NOT
-    share an env: the contract of `mixed` is that each test gets a fresh
-    spin-up. Before the fix, `setup_details["env"]` was left populated after
-    the first mixed test and the dispatcher took the reuse branch on the
-    second one.
-
-    Invariant: after publishing the mixed env to `shared_env`,
-    `setup_details["env"]` must be cleared so the next iteration re-enters the
-    spin-up branch (`if setup_details["env"] is None`).
-    """
+def test_save_env_for_cross_type_reuse_publishes_to_shared_env():
+    """`save_env_for_cross_type_reuse` publishes the spun-up env to `shared_env`
+    when `reuse_mixed=True`, so a subsequent group on the same
+    `(setup, dataset)` can inherit it via the cross-type handoff."""
     fake_env = {"redis_pids": [1234], "redis_conns": []}
     setup_details = {"env": fake_env}
     shared_env = {}
     env_key = ("ds1", "oss-standalone")
 
     published = save_env_for_cross_type_reuse(
-        benchmark_type="mixed",
         reuse_mixed=True,
         env_key=env_key,
         setup_details=setup_details,
@@ -434,42 +425,20 @@ def test_save_env_for_cross_type_reuse_mixed_clears_setup_details():
     )
 
     assert published is True
-    assert setup_details["env"] is None
     assert shared_env[env_key] is fake_env
-
-
-def test_save_env_for_cross_type_reuse_read_only_keeps_setup_details():
-    """In run_local, `reuse_mixed=True` publishes for read-only too, so a
-    subsequent group on the same `(setup, dataset)` can pick the env up. But
-    `setup_details["env"]` must NOT be cleared: read-only's contract is that
-    state is pure and the env can (and should) be reused within the group."""
-    fake_env = {"redis_pids": [1234], "redis_conns": []}
-    setup_details = {"env": fake_env}
-    shared_env = {}
-    env_key = ("ds1", "oss-standalone")
-
-    published = save_env_for_cross_type_reuse(
-        benchmark_type="read-only",
-        reuse_mixed=True,
-        env_key=env_key,
-        setup_details=setup_details,
-        shared_env=shared_env,
-    )
-
-    assert published is True
+    # The env stays in setup_details too — the dispatcher reads it on the
+    # next iteration to decide spin-up vs reuse.
     assert setup_details["env"] is fake_env
-    assert shared_env[env_key] is fake_env
 
 
 def test_save_env_for_cross_type_reuse_disabled_is_noop():
-    """When `reuse_mixed` is False, neither publish nor clear happens."""
+    """When `reuse_mixed` is False, no publish to shared_env happens."""
     fake_env = {"redis_pids": [1234], "redis_conns": []}
     setup_details = {"env": fake_env}
     shared_env = {}
     env_key = ("ds1", "oss-standalone")
 
     published = save_env_for_cross_type_reuse(
-        benchmark_type="mixed",
         reuse_mixed=False,
         env_key=env_key,
         setup_details=setup_details,
@@ -479,3 +448,131 @@ def test_save_env_for_cross_type_reuse_disabled_is_noop():
     assert published is False
     assert setup_details["env"] is fake_env
     assert shared_env == {}
+
+
+def test_tear_down_previous_mixed_env_clears_and_removes_from_shared_env(monkeypatch):
+    """Regression for the `mixed -> mixed` env-leak bug.
+
+    Between two mixed tests sharing `(setup, dataset)`, the previous test's
+    Redis env must be torn down and `setup_details["env"]` cleared so the
+    dispatcher takes the spin-up path for the next mixed test (rather than
+    the reuse branch, which asserts `benchmark_type == "read-only"`). The
+    env must also be removed from `shared_env` since the Redis it references
+    no longer exists."""
+    from redisbench_admin.run_local import run_local as run_local_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_local_mod,
+        "teardown_local_setup",
+        lambda conns, procs, name: teardown_calls.append((conns, procs, name)),
+    )
+
+    fake_env = {"redis_pids": [1234], "redis_conns": ["c1"], "redis_processes": ["p1"]}
+    setup_details = {"env": fake_env}
+    env_key = ("ds1", "oss-standalone")
+    shared_env = {env_key: fake_env}
+
+    tore_down = run_local_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=env_key,
+        keep_env_and_topo=False,
+    )
+
+    assert tore_down is True
+    assert teardown_calls == [(["c1"], ["p1"], "previous-mixed")]
+    assert setup_details["env"] is None
+    assert shared_env == {}
+
+
+def test_tear_down_previous_mixed_env_noop_on_first_iteration(monkeypatch):
+    """First iteration in a mixed group: `setup_details["env"]` is None — no
+    previous env to tear down. Helper must be a no-op."""
+    from redisbench_admin.run_local import run_local as run_local_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_local_mod,
+        "teardown_local_setup",
+        lambda conns, procs, name: teardown_calls.append((conns, procs, name)),
+    )
+
+    setup_details = {"env": None}
+    shared_env = {}
+
+    tore_down = run_local_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=("ds1", "oss-standalone"),
+        keep_env_and_topo=False,
+    )
+
+    assert tore_down is False
+    assert teardown_calls == []
+
+
+def test_tear_down_previous_mixed_env_noop_for_read_only(monkeypatch):
+    """Read-only types intentionally reuse env within a group (that's the
+    original RO optimization); the helper must not interfere."""
+    from redisbench_admin.run_local import run_local as run_local_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_local_mod,
+        "teardown_local_setup",
+        lambda conns, procs, name: teardown_calls.append((conns, procs, name)),
+    )
+
+    fake_env = {"redis_pids": [1234], "redis_conns": ["c1"], "redis_processes": ["p1"]}
+    setup_details = {"env": fake_env}
+    env_key = ("ds1", "oss-standalone")
+    shared_env = {env_key: fake_env}
+
+    tore_down = run_local_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="read-only",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=env_key,
+        keep_env_and_topo=False,
+    )
+
+    assert tore_down is False
+    assert teardown_calls == []
+    assert setup_details["env"] is fake_env
+    assert shared_env[env_key] is fake_env
+
+
+def test_tear_down_previous_mixed_env_noop_when_keep_env_and_topo(monkeypatch):
+    """`--keep-env-and-topo` is the user explicitly opting out of teardown —
+    the helper must respect that even for mixed groups."""
+    from redisbench_admin.run_local import run_local as run_local_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_local_mod,
+        "teardown_local_setup",
+        lambda conns, procs, name: teardown_calls.append((conns, procs, name)),
+    )
+
+    fake_env = {"redis_pids": [1234], "redis_conns": ["c1"], "redis_processes": ["p1"]}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+
+    tore_down = run_local_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=("ds1", "oss-standalone"),
+        keep_env_and_topo=True,
+    )
+
+    assert tore_down is False
+    assert teardown_calls == []
+    assert setup_details["env"] is fake_env

--- a/tests/test_run_local.py
+++ b/tests/test_run_local.py
@@ -247,6 +247,45 @@ def test_run_local_command_logic():
         assert e.code == 0
 
 
+def test_run_local_mixed_env_no_leak():
+    """Regression test: two `mixed` benchmarks sharing (setup, dataset_name)
+    plus one `read-only` benchmark must complete without crashing.
+
+    The plan is:
+      - mixed-load.yml   (benchmark_type=mixed,     dataset=mixed-env-leak)
+      - mixed-load2.yml  (benchmark_type=mixed,     dataset=mixed-env-leak)
+      - read-query.yml   (benchmark_type=read-only, dataset=mixed-env-leak)
+
+    The presence of both mixed and read-only flips `reuse_mixed` to True, and
+    the two mixed benchmarks land in the same (setup, dataset) group. Pre-fix,
+    the second mixed test inherited the first one's populated `setup_details
+    ["env"]` and got routed through `ro_benchmark_reuse`, which asserts
+    `benchmark_type == "read-only"` and crashed. Post-fix, each mixed test
+    spins up its own fresh env; the read-only test reuses the env from the
+    last mixed test via `shared_env`.
+    """
+    parser = argparse.ArgumentParser(
+        description="test",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser = create_run_local_arguments(parser)
+    args = parser.parse_args(
+        args=[
+            "--test-glob",
+            "./tests/test_data/mixed_env_leak/*.yml",
+        ]
+    )
+    try:
+        run_local_command_logic(args, "tool", "v0")
+    except SystemExit as e:
+        assert e.code == 0, (
+            f"run_local_command_logic exited with code {e.code} — the "
+            "mixed -> mixed env leak likely tripped the "
+            "ro_benchmark_reuse `assert benchmark_type == 'read-only'` "
+            "invariant."
+        )
+
+
 def test_run_local_dataset_reuse_memtier():
     """
     Test that benchmarks with the same dataset_name are grouped together

--- a/tests/test_run_remote.py
+++ b/tests/test_run_remote.py
@@ -16,6 +16,7 @@ from redisbench_admin.run_remote.run_remote import (
     export_redis_metrics,
     run_remote_command_logic,
     save_env_for_cross_type_reuse,
+    tear_down_previous_mixed_env_if_needed,
 )
 from redisbench_admin.utils.remote import check_ec2_env
 
@@ -350,20 +351,10 @@ def test_run_remote_dataset_reuse_memtier():
         assert e.code == 0, f"run_remote_command_logic exited with code {e.code}"
 
 
-def test_save_env_for_cross_type_reuse_mixed_clears_setup_details():
-    """Regression for the `mixed -> mixed` env-leak bug.
-
-    Two mixed tests sharing `(setup, dataset)` with `reuse_mixed=True` must NOT
-    share an env: the contract of `mixed` is that each test gets a fresh
-    spin-up. Before the fix, `setup_details["env"]` was left populated after
-    the first mixed test, the dispatcher took the reuse branch on the second
-    one, and `ro_benchmark_reuse` crashed on
-    `assert benchmark_type == "read-only"`.
-
-    Invariant: after publishing the mixed env to `shared_env`,
-    `setup_details["env"]` must be cleared so the next iteration re-enters the
-    spin-up branch (`if setup_details.get("env") is None`).
-    """
+def test_save_env_for_cross_type_reuse_publishes_to_shared_env():
+    """`save_env_for_cross_type_reuse` publishes a mixed benchmark's spun-up
+    env to `shared_env` so a subsequent read-only group on the same
+    `(setup, dataset)` can inherit it via the cross-type handoff."""
     fake_env = {"redis_pids": [1234], "server_plaintext_port": 6379}
     setup_details = {"env": fake_env}
     shared_env = {}
@@ -378,10 +369,10 @@ def test_save_env_for_cross_type_reuse_mixed_clears_setup_details():
     )
 
     assert published is True
-    # Cleared so the next mixed test in the group spins up fresh.
-    assert setup_details["env"] is None
-    # Still available for the next read-only group on the same (setup, dataset).
     assert shared_env[("ds1", "oss-standalone")] is fake_env
+    # The env stays in setup_details too — the dispatcher reads it on the
+    # next iteration to decide spin-up vs reuse.
+    assert setup_details["env"] is fake_env
 
 
 def test_save_env_for_cross_type_reuse_read_only_is_noop():
@@ -407,10 +398,10 @@ def test_save_env_for_cross_type_reuse_read_only_is_noop():
 
 
 def test_save_env_for_cross_type_reuse_mixed_without_reuse_mixed_is_noop():
-    """If `reuse_mixed` is False, mixed benchmarks neither publish nor clear:
-    the cross-type handoff is disabled and standard mixed semantics apply
-    (each iteration re-enters the spin-up branch on its own, because env was
-    teared down between tests)."""
+    """If `reuse_mixed` is False, the cross-type handoff is disabled — neither
+    publish happens. Each mixed test is then expected to be torn down between
+    iterations via the existing teardown logic (no inter-group reuse to
+    preserve)."""
     fake_env = {"redis_pids": [1234]}
     setup_details = {"env": fake_env}
     shared_env = {}
@@ -427,3 +418,136 @@ def test_save_env_for_cross_type_reuse_mixed_without_reuse_mixed_is_noop():
     assert published is False
     assert setup_details["env"] is fake_env
     assert shared_env == {}
+
+
+def test_tear_down_previous_mixed_env_clears_and_removes_from_shared_env(monkeypatch):
+    """Regression for the `mixed -> mixed` env-leak bug.
+
+    Between two mixed tests sharing `(setup, dataset)`, the previous test's
+    remote Redis env must be torn down and `setup_details["env"]` cleared so
+    the dispatcher takes the spin-up path for the next mixed test (rather
+    than the reuse branch, which asserts `benchmark_type == "read-only"`).
+    The env must also be removed from `shared_env` since the Redis it
+    references no longer exists."""
+    from redisbench_admin.run_remote import run_remote as run_remote_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_remote_mod,
+        "shutdown_remote_redis",
+        lambda conns, tunnel: teardown_calls.append((conns, tunnel)),
+    )
+
+    fake_tunnel = object()
+    fake_env = {"redis_conns": ["c1"], "ssh_tunnel": fake_tunnel}
+    setup_details = {"env": fake_env}
+    env_key = ("ds1", "oss-standalone")
+    shared_env = {env_key: fake_env}
+
+    tore_down = run_remote_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=env_key,
+        keep_env_and_topo=False,
+        skip_remote_db_setup=False,
+    )
+
+    assert tore_down is True
+    assert teardown_calls == [(["c1"], fake_tunnel)]
+    assert setup_details["env"] is None
+    assert shared_env == {}
+
+
+def test_tear_down_previous_mixed_env_noop_on_first_iteration(monkeypatch):
+    """First iteration in a mixed group: `setup_details["env"]` is None — no
+    previous env to tear down. Helper must be a no-op."""
+    from redisbench_admin.run_remote import run_remote as run_remote_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_remote_mod,
+        "shutdown_remote_redis",
+        lambda conns, tunnel: teardown_calls.append((conns, tunnel)),
+    )
+
+    setup_details = {"env": None}
+    shared_env = {}
+
+    tore_down = run_remote_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=("ds1", "oss-standalone"),
+        keep_env_and_topo=False,
+        skip_remote_db_setup=False,
+    )
+
+    assert tore_down is False
+    assert teardown_calls == []
+
+
+def test_tear_down_previous_mixed_env_noop_for_read_only(monkeypatch):
+    """Read-only types intentionally reuse env within a group (that's the
+    original RO optimization); the helper must not interfere."""
+    from redisbench_admin.run_remote import run_remote as run_remote_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_remote_mod,
+        "shutdown_remote_redis",
+        lambda conns, tunnel: teardown_calls.append((conns, tunnel)),
+    )
+
+    fake_env = {"redis_conns": ["c1"], "ssh_tunnel": object()}
+    setup_details = {"env": fake_env}
+    env_key = ("ds1", "oss-standalone")
+    shared_env = {env_key: fake_env}
+
+    tore_down = run_remote_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="read-only",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=env_key,
+        keep_env_and_topo=False,
+        skip_remote_db_setup=False,
+    )
+
+    assert tore_down is False
+    assert teardown_calls == []
+    assert setup_details["env"] is fake_env
+    assert shared_env[env_key] is fake_env
+
+
+def test_tear_down_previous_mixed_env_noop_when_keep_env_and_topo(monkeypatch):
+    """`--keep-env-and-topo` is the user explicitly opting out of teardown —
+    the helper must respect that even for mixed groups."""
+    from redisbench_admin.run_remote import run_remote as run_remote_mod
+
+    teardown_calls = []
+    monkeypatch.setattr(
+        run_remote_mod,
+        "shutdown_remote_redis",
+        lambda conns, tunnel: teardown_calls.append((conns, tunnel)),
+    )
+
+    fake_env = {"redis_conns": ["c1"], "ssh_tunnel": object()}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+
+    tore_down = run_remote_mod.tear_down_previous_mixed_env_if_needed(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        setup_details=setup_details,
+        shared_env=shared_env,
+        env_key=("ds1", "oss-standalone"),
+        keep_env_and_topo=True,
+        skip_remote_db_setup=False,
+    )
+
+    assert tore_down is False
+    assert teardown_calls == []
+    assert setup_details["env"] is fake_env

--- a/tests/test_run_remote.py
+++ b/tests/test_run_remote.py
@@ -204,6 +204,77 @@ def test_export_redis_metrics():
         pass
 
 
+def test_run_remote_mixed_env_no_leak():
+    """Regression test for the `mixed -> mixed` env-leak bug, in remote mode.
+
+    Plan:
+      - mixed-load.yml   (benchmark_type=mixed,     dataset=mixed-env-leak)
+      - mixed-load2.yml  (benchmark_type=mixed,     dataset=mixed-env-leak)
+      - read-query.yml   (benchmark_type=read-only, dataset=mixed-env-leak)
+
+    Pre-fix, the second mixed benchmark inherited the populated
+    `setup_details["env"]` from the first and was routed through
+    `ro_benchmark_reuse`, which asserts `benchmark_type == "read-only"`.
+    Post-fix, each mixed test spins up fresh; the read-only test inherits the
+    env from the last mixed test via `shared_env`.
+
+    Same infrastructure requirements as test_run_remote_dataset_reuse_memtier:
+    RUN_REMOTE_TESTS=1 plus either AWS credentials or pre-deployed inventory.
+    """
+    if os.getenv("RUN_REMOTE_TESTS", "0") != "1":
+        pytest.skip("Remote tests disabled. Set RUN_REMOTE_TESTS=1 to enable.")
+
+    db_server_ip = os.getenv("DB_SERVER_HOST", None)
+    client_server_ip = os.getenv("CLIENT_SERVER_HOST", None)
+    private_key_path = os.getenv(
+        "EC2_PRIVATE_PEM", "./tests/test_data/test-ssh/tox_rsa"
+    )
+
+    has_inventory = db_server_ip is not None and client_server_ip is not None
+    has_aws_credentials, _ = check_ec2_env()
+
+    if not has_inventory and not has_aws_credentials:
+        pytest.skip(
+            "This test requires either pre-deployed inventory "
+            "(DB_SERVER_HOST, CLIENT_SERVER_HOST) or AWS credentials "
+            "(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION)"
+        )
+
+    parser = argparse.ArgumentParser(
+        description="test",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser = create_run_remote_arguments(parser)
+
+    args_list = [
+        "--test-glob",
+        "./tests/test_data/mixed_env_leak/*.yml",
+        "--skip-env-vars-verify",
+    ]
+
+    if has_inventory:
+        args_list.extend(
+            [
+                "--inventory",
+                f"server_private_ip={db_server_ip},server_public_ip={db_server_ip},client_public_ip={client_server_ip}",
+                "--private_key",
+                private_key_path,
+            ]
+        )
+
+    args = parser.parse_args(args=args_list)
+
+    try:
+        run_remote_command_logic(args, "tool", "v0")
+    except SystemExit as e:
+        assert e.code == 0, (
+            f"run_remote_command_logic exited with code {e.code} — the "
+            "mixed -> mixed env leak likely tripped the "
+            "ro_benchmark_reuse `assert benchmark_type == 'read-only'` "
+            "invariant."
+        )
+
+
 def test_run_remote_dataset_reuse_memtier():
     """
     Test that benchmarks with the same dataset_name are grouped together

--- a/tests/test_run_remote.py
+++ b/tests/test_run_remote.py
@@ -15,6 +15,7 @@ from redisbench_admin.run_remote.args import create_run_remote_arguments
 from redisbench_admin.run_remote.run_remote import (
     export_redis_metrics,
     run_remote_command_logic,
+    save_env_for_cross_type_reuse,
 )
 from redisbench_admin.utils.remote import check_ec2_env
 
@@ -276,3 +277,82 @@ def test_run_remote_dataset_reuse_memtier():
         run_remote_command_logic(args, "tool", "v0")
     except SystemExit as e:
         assert e.code == 0, f"run_remote_command_logic exited with code {e.code}"
+
+
+def test_save_env_for_cross_type_reuse_mixed_clears_setup_details():
+    """Regression for the `mixed -> mixed` env-leak bug.
+
+    Two mixed tests sharing `(setup, dataset)` with `reuse_mixed=True` must NOT
+    share an env: the contract of `mixed` is that each test gets a fresh
+    spin-up. Before the fix, `setup_details["env"]` was left populated after
+    the first mixed test, the dispatcher took the reuse branch on the second
+    one, and `ro_benchmark_reuse` crashed on
+    `assert benchmark_type == "read-only"`.
+
+    Invariant: after publishing the mixed env to `shared_env`,
+    `setup_details["env"]` must be cleared so the next iteration re-enters the
+    spin-up branch (`if setup_details.get("env") is None`).
+    """
+    fake_env = {"redis_pids": [1234], "server_plaintext_port": 6379}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+
+    published = save_env_for_cross_type_reuse(
+        benchmark_type="mixed",
+        reuse_mixed=True,
+        dataset_name="ds1",
+        setup_name="oss-standalone",
+        setup_details=setup_details,
+        shared_env=shared_env,
+    )
+
+    assert published is True
+    # Cleared so the next mixed test in the group spins up fresh.
+    assert setup_details["env"] is None
+    # Still available for the next read-only group on the same (setup, dataset).
+    assert shared_env[("ds1", "oss-standalone")] is fake_env
+
+
+def test_save_env_for_cross_type_reuse_read_only_is_noop():
+    """Read-only benchmarks do not publish via this path in run_remote: env is
+    kept in `setup_details["env"]` so the next read-only test in the group can
+    reuse it through the dispatcher's reuse branch."""
+    fake_env = {"redis_pids": [1234]}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+
+    published = save_env_for_cross_type_reuse(
+        benchmark_type="read-only",
+        reuse_mixed=True,
+        dataset_name="ds1",
+        setup_name="oss-standalone",
+        setup_details=setup_details,
+        shared_env=shared_env,
+    )
+
+    assert published is False
+    assert setup_details["env"] is fake_env
+    assert shared_env == {}
+
+
+def test_save_env_for_cross_type_reuse_mixed_without_reuse_mixed_is_noop():
+    """If `reuse_mixed` is False, mixed benchmarks neither publish nor clear:
+    the cross-type handoff is disabled and standard mixed semantics apply
+    (each iteration re-enters the spin-up branch on its own, because env was
+    teared down between tests)."""
+    fake_env = {"redis_pids": [1234]}
+    setup_details = {"env": fake_env}
+    shared_env = {}
+
+    published = save_env_for_cross_type_reuse(
+        benchmark_type="mixed",
+        reuse_mixed=False,
+        dataset_name="ds1",
+        setup_name="oss-standalone",
+        setup_details=setup_details,
+        shared_env=shared_env,
+    )
+
+    assert published is False
+    assert setup_details["env"] is fake_env
+    assert shared_env == {}


### PR DESCRIPTION
## Summary

Fixes a latent bug where two `benchmark_type: "mixed"` benchmarks sharing the same `(setup, dataset_name)` crashed on `assert benchmark_type == "read-only"` inside `ro_benchmark_reuse`, because the second test inherited the first one's populated `setup_details["env"]` and got routed through the reuse branch.

The fix is two-part: a refactor of the post-spin-up publish to `shared_env`, plus a new pre-iteration teardown for mixed groups. (An initial one-line fix avoided the assertion crash but broke the cross-type handoff — see "Why the bug report's one-liner isn't enough" below.)

## The bug

`mixed` semantically means "this workload may mutate state, so each test in the group must get a fresh Redis env." The framework respected that for the cross-*type* handoff (mixed → read-only on the same dataset) but not for the intra-*group* case.

Triggers when a plan satisfies all of:

1. Contains at least one `read-only` and at least one `mixed` benchmark → sets `reuse_mixed = True`.
2. Contains two or more `mixed` benchmarks sharing the same `(setup, dataset_name)`.

Symptom:
```
File "redisbench_admin/run_remote/run_remote.py", line 786, in run_remote_command_logic
    ) = ro_benchmark_reuse(
File "redisbench_admin/run_remote/run_remote.py", line 1896, in ro_benchmark_reuse
    assert benchmark_type == "read-only"
AssertionError
```

Real-world repro on RediSearch master: `search-expire-doc-1000-seconds.yml` and `search-expire-write-read-concurrent.yml` are both `mixed`, both target `dataset_name: "5200K-docs-union-iterators.idx10-expire-doc-1000s"`, share the same 8-setup list, and the surrounding `search*.yml` glob includes plenty of read-only tests — whichever of the two mixed tests runs second in its group hits the assertion.

## Why the bug report's one-liner isn't enough

The original proposal was a single line: after publishing the mixed env to `shared_env`, clear `setup_details["env"]` so the next iteration takes the spin-up branch. That avoids the assertion crash — but `run_local.py:736`'s per-iteration teardown uses `setup_details["env"] is None` as the "tear down Redis" signal:

```python
if setup_details["env"] is None:
    if args.keep_env_and_topo is False:
        teardown_local_setup(redis_conns, redis_processes, setup_name)
```

So the one-liner *also* causes the per-iteration teardown to kill the Redis whose env was just published to `shared_env`. The subsequent read-only group inherits a dict pointing to dead processes and crashes with `ConnectionRefusedError`. The integration test in this PR caught that regression on the **existing** `test_run_local_dataset_reuse_memtier` scenario (one mixed + read-only on the same dataset, which works on master today). The bug report's "the handoff still works because `shared_env` holds the env" assertion didn't account for the per-iteration teardown also killing the processes the env references.

The same loop in `run_remote.py:1391` already has an `is_shared` check that protects the handoff there, but the inter-iteration teardown story is still needed for cleanliness; the fix is applied symmetrically.

## The fix (two parts)

### 1. `save_env_for_cross_type_reuse` just publishes, no clearing

Pulled the publish into a named helper in both files. It writes `setup_details["env"]` into `shared_env[env_key]` when `reuse_mixed=True` and leaves `setup_details["env"]` populated. The env stays alive across the inner loop iteration (and the existing end-of-group logic preserves it for the cross-type handoff).

### 2. New `tear_down_previous_mixed_env_if_needed` helper, called at the top of each inner-loop iteration

For mixed groups with `reuse_mixed=True`, this helper looks at `setup_details["env"]` *from the previous iteration*. If populated, it tears down that Redis (via `teardown_local_setup` / `shutdown_remote_redis`), removes the corresponding entry from `shared_env` (the Redis it references is now dead), and clears `setup_details["env"]` — so the dispatcher takes the spin-up branch.

No-op cases (all important):
- **First iteration in a group** — `setup_details["env"]` is None, nothing to tear down.
- **Read-only types** — read-only tests are *meant* to reuse env within a group (the original RO optimization predating `reuse_mixed`).
- **`--keep-env-and-topo`** — user explicitly opted out of teardown.

The result is the correct semantics:

- Each mixed test runs against a fresh Redis env.
- The **last** mixed test's env stays alive at end-of-group (because the helper is a no-op when env is None — the last iteration doesn't tear itself down).
- End-of-group logic (`run_local.py:752`, equivalent in `run_remote.py`) sees the env in `shared_env`, marks `is_shared=True`, and preserves it.
- The read-only group on the same `(setup, dataset)` picks it up via the existing `shared_env[env_key]` handoff at the top of the next outer-loop iteration.
- The `ro_benchmark_reuse` call site is no longer reached on the mixed path, so the `assert benchmark_type == "read-only"` invariant is preserved as a belt-and-braces check.

Applied symmetrically to `run_remote.py` (`shutdown_remote_redis` for the teardown, with the extra `skip_remote_db_setup` no-op case for the remote-specific opt-out).

## Tests

### Integration tests (run in CI alongside the existing dataset-reuse tests)

- **`tests/test_run_local.py::test_run_local_mixed_env_no_leak`** — drives `run_local_command_logic` end-to-end with a new plan (`tests/test_data/mixed_env_leak/*.yml`) containing two `mixed` benchmarks plus one `read-only` benchmark, all on the same `(setup="oss-standalone", dataset_name="mixed-env-leak")`. Pre-fix this would crash on the assertion. Post-fix the run completes with exit code 0; each mixed test gets a fresh spin-up and the read-only test reuses the env from the last mixed test. Uses `memtier_benchmark`, which CI already installs from apt.
- **`tests/test_run_remote.py::test_run_remote_mixed_env_no_leak`** — same plan, driven through `run_remote_command_logic`. Gated behind `RUN_REMOTE_TESTS=1` like the existing `test_run_remote_dataset_reuse_memtier`.

### Unit tests (fast feedback for the helpers)

- `test_save_env_for_cross_type_reuse_publishes_to_shared_env` / `_disabled_is_noop` / `_read_only_is_noop` (remote-specific) / `_mixed_without_reuse_mixed_is_noop` — lock in the publish semantics.
- `test_tear_down_previous_mixed_env_clears_and_removes_from_shared_env` / `_noop_on_first_iteration` / `_noop_for_read_only` / `_noop_when_keep_env_and_topo` — lock in the four key invariants of the teardown helper, using `monkeypatch` to intercept the actual teardown calls.

### Verification done locally

- New integration test passes (`memtier_benchmark` available locally).
- Mixed → read-only handoff verified by running `vanilla-memtier-load.yml` + `vanilla-memtier-query{,2}.yml` end-to-end → exit code 0.
- `test_run_local_dataset_reuse_memtier` fails locally on `vanilla-memtier-monitor-input.yml` because the apt-installed `memtier_benchmark 2.1.4` on my machine doesn't support `--monitor-input`; CI uses a newer build and the test passes there (last master run: 206 passed, 1 skipped).
- `black --check` clean on all four touched files.

## Out of scope

Two mixed benchmarks sharing `(setup, dataset)` each pay their own fresh spin-up — that's the contract of `mixed`. If a benchmark author *wants* to share state between two mixed tests (e.g. warm-up + measured-run), a separate explicit opt-in (e.g. `share_env_with: <prev-test-name>` in `clientconfig`) would be cleaner than the implicit state-leak the old code produced. Flagged for future work.
