### PR TITLE
compare: scope PR-comment upsert per (deployment, triggering_env)

### DIFF
--- a/redisbench_admin/compare/compare.py
+++ b/redisbench_admin/compare/compare.py
@@ -376,6 +376,11 @@ def compare_command_logic(args, project_name, project_version):
             comparison_deployment_name,
         )
     )
+    upsert_marker = build_upsert_marker(
+        baseline_deployment_name,
+        comparison_deployment_name,
+        tf_triggering_env,
+    )
     from_ts_ms = args.from_timestamp
     to_ts_ms = args.to_timestamp
     from_date = args.from_date
@@ -495,7 +500,9 @@ def compare_command_logic(args, project_name, project_version):
             pr_link = github_pr.html_url
             logging.info("Working on github PR already: {}".format(pr_link))
             is_actionable_pr = True
-            contains_regression_comment, pos = check_regression_comment(comments)
+            contains_regression_comment, pos = check_regression_comment(
+                comments, marker=upsert_marker
+            )
             if contains_regression_comment:
                 regression_comment = comments[pos]
                 old_regression_comment_body = regression_comment.body
@@ -801,6 +808,12 @@ def compare_command_logic(args, project_name, project_version):
     # Upsert the PR comment (shared between legacy + multi-arch paths).
     # ------------------------------------------------------------------
     if comment_body:
+        if is_actionable_pr:
+            # Append the upsert marker so future compare runs from the same
+            # (deployment, triggering_env) tuple find this comment and edit
+            # it in place rather than colliding with a sibling matrix
+            # entry's comment.
+            comment_body += "\n\n" + upsert_marker
         print(comment_body)
         if is_actionable_pr:
             zset_project_pull_request = get_project_compare_zsets(
@@ -937,14 +950,62 @@ def compare_command_logic(args, project_name, project_version):
     )
 
 
-def check_regression_comment(comments):
+UPSERT_MARKER_PREFIX = "<!-- redisbench-admin:upsert"
+
+
+def build_upsert_marker(
+    baseline_deployment_name,
+    comparison_deployment_name,
+    tf_triggering_env,
+):
+    """Build the hidden HTML marker used to identify *this* compare invocation's
+    PR comment for upsert.
+
+    Concurrent compare runs against the same PR (one per matrix entry --
+    different deployments, different triggering envs) used to collide on the
+    legacy "Comparison between"/"Time Period from" predicate and overwrite each
+    other's comments. Embedding the deployment + triggering_env in a stable
+    marker lets the matcher scope upsert to comments produced by the same
+    (deployment, triggering_env) tuple, so each setup gets its own comment.
+
+    Architecture is intentionally NOT part of the key: in multi-arch mode a
+    single comment renders one H2 section per arch, and as additional arches
+    finish we want to upsert that one comment rather than fragment it.
+    """
+    return (
+        f"{UPSERT_MARKER_PREFIX} "
+        f"baseline_deployment={baseline_deployment_name} "
+        f"comparison_deployment={comparison_deployment_name} "
+        f"triggering_env={tf_triggering_env} -->"
+    )
+
+
+def check_regression_comment(comments, marker=None):
+    """Locate the PR comment to upsert.
+
+    When `marker` is provided, only comments containing that exact marker
+    substring match -- so concurrent compare runs targeting the same PR with
+    different (deployment, triggering_env) tuples each upsert their own
+    comment. When no comment carries the marker, returns (False, -1) so the
+    caller posts a fresh comment (any pre-marker legacy comment is left in
+    place as an orphan rather than silently overwritten with a body from a
+    different setup).
+
+    When `marker` is None the legacy generic predicate is used, preserving
+    behavior for callers that don't yet pass a marker.
+    """
     res = False
     pos = -1
     for n, comment in enumerate(comments):
         body = comment.body
-        if "Comparison between" in body and "Time Period from" in body:
-            res = True
-            pos = n
+        if marker is not None:
+            if marker in body:
+                res = True
+                pos = n
+        else:
+            if "Comparison between" in body and "Time Period from" in body:
+                res = True
+                pos = n
     return res, pos
 
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -6,7 +6,11 @@ import pytest
 import redis
 
 from redisbench_admin.compare.args import create_compare_arguments
-from redisbench_admin.compare.compare import compare_command_logic
+from redisbench_admin.compare.compare import (
+    build_upsert_marker,
+    check_regression_comment,
+    compare_command_logic,
+)
 from redisbench_admin.export.args import create_export_arguments
 from redisbench_admin.export.export import export_command_logic
 
@@ -493,3 +497,132 @@ def test_compare_architectures_single_entry_no_cross_arch() -> None:
     assert "## Architecture: `x86_64` — branch-over-branch" in result.comment_body
     assert "## Architecture: `aarch64`" not in result.comment_body
     assert "## Cross-arch delta" not in result.comment_body
+
+
+# ----------------------------------------------------------------------------
+# Unit tests for the PR-comment upsert marker / matcher. No live RTS required.
+# ----------------------------------------------------------------------------
+
+
+class _FakeComment:
+    """Minimal stand-in for github.IssueComment.IssueComment used by
+    `check_regression_comment` -- only `.body` is read."""
+
+    def __init__(self, body: str) -> None:
+        self.body = body
+
+
+def test_build_upsert_marker_is_deterministic_and_html_hidden() -> None:
+    a = build_upsert_marker("oss-standalone", "oss-standalone", "circleci")
+    b = build_upsert_marker("oss-standalone", "oss-standalone", "circleci")
+    assert a == b
+    assert a.startswith("<!--")
+    assert a.endswith("-->")
+    assert "oss-standalone" in a
+    assert "circleci" in a
+
+
+def test_build_upsert_marker_differs_per_deployment() -> None:
+    standalone = build_upsert_marker("oss-standalone", "oss-standalone", "circleci")
+    cluster = build_upsert_marker(
+        "oss-cluster-02-primaries",
+        "oss-cluster-02-primaries",
+        "circleci",
+    )
+    threads = build_upsert_marker(
+        "oss-standalone-threads-8",
+        "oss-standalone-threads-8",
+        "circleci",
+    )
+    assert standalone != cluster
+    assert standalone != threads
+    assert cluster != threads
+    # And no marker is a substring of another -- the prefix-collision guard
+    # for setups whose names share a prefix (e.g. `oss-standalone` vs
+    # `oss-standalone-threads-8`).
+    assert standalone not in cluster
+    assert standalone not in threads
+
+
+def test_build_upsert_marker_differs_per_triggering_env() -> None:
+    circle = build_upsert_marker("oss-standalone", "oss-standalone", "circleci")
+    actions = build_upsert_marker("oss-standalone", "oss-standalone", "github-actions")
+    assert circle != actions
+
+
+def test_check_regression_comment_legacy_predicate_when_no_marker() -> None:
+    comments = [
+        _FakeComment("unrelated comment"),
+        _FakeComment(
+            "## Performance Regressions and Issues - "
+            "Comparison between master and feature.\n\n"
+            "Time Period from 2026-01-01 to 2026-02-01. (environment used: ci)\n"
+        ),
+        _FakeComment("another unrelated comment"),
+    ]
+    found, pos = check_regression_comment(comments)
+    assert found is True
+    assert pos == 1
+
+
+def test_check_regression_comment_no_match_returns_false() -> None:
+    comments = [_FakeComment("hello"), _FakeComment("world")]
+    found, pos = check_regression_comment(comments)
+    assert found is False
+    assert pos == -1
+
+
+def test_check_regression_comment_with_marker_matches_only_same_marker() -> None:
+    marker_standalone = build_upsert_marker(
+        "oss-standalone", "oss-standalone", "circleci"
+    )
+    marker_cluster = build_upsert_marker(
+        "oss-cluster-02-primaries",
+        "oss-cluster-02-primaries",
+        "circleci",
+    )
+    comments = [
+        _FakeComment("body for standalone\n\n" + marker_standalone),
+        _FakeComment("body for cluster\n\n" + marker_cluster),
+    ]
+    found, pos = check_regression_comment(comments, marker=marker_standalone)
+    assert found is True
+    assert pos == 0
+
+    found, pos = check_regression_comment(comments, marker=marker_cluster)
+    assert found is True
+    assert pos == 1
+
+
+def test_check_regression_comment_with_marker_ignores_legacy_comments() -> None:
+    # A PR that already has a pre-fix comment posted by an older
+    # redisbench-admin must NOT be overwritten with a body produced for a
+    # different setup; the matcher should return (False, -1) so the caller
+    # creates a new marker-tagged comment and leaves the legacy one alone.
+    marker = build_upsert_marker(
+        "oss-standalone-threads-8",
+        "oss-standalone-threads-8",
+        "circleci",
+    )
+    legacy_body = (
+        "## Performance Regressions and Issues - "
+        "Comparison between master and feature.\n\n"
+        "Time Period from 2026-01-01 to 2026-02-01. (environment used: ci)\n"
+    )
+    found, pos = check_regression_comment([_FakeComment(legacy_body)], marker=marker)
+    assert found is False
+    assert pos == -1
+
+
+def test_check_regression_comment_with_marker_returns_last_match() -> None:
+    # If somehow two comments share the same marker (shouldn't happen in
+    # practice, but possible if a user manually duplicated one), prefer the
+    # last to mirror legacy behavior.
+    marker = build_upsert_marker("oss-standalone", "oss-standalone", "circleci")
+    comments = [
+        _FakeComment("first\n\n" + marker),
+        _FakeComment("second\n\n" + marker),
+    ]
+    found, pos = check_regression_comment(comments, marker=marker)
+    assert found is True
+    assert pos == 1


### PR DESCRIPTION
## Summary

`check_regression_comment` matches on the literal substrings `"Comparison between"` and `"Time Period from"` — strings that appear in *every* regression-table comment regardless of which deployment or triggering env produced it. So when several matrix entries (e.g. `oss-standalone` + `oss-cluster-02-primaries`, or msmarco + ftsb) each run `compare --pull-request N` against the same PR, the second invocation finds the first's comment via that generic predicate and calls `regression_comment.edit(comment_body)` (compare.py:876), silently overwriting the previous setup's results. Net effect on the PR: only whichever setup finishes last is visible.

This PR scopes the upsert per `(deployment, triggering_env)` tuple so each setup gets its own comment.

## Changes

- **New helper** `build_upsert_marker(baseline_deployment_name, comparison_deployment_name, tf_triggering_env)` returns a stable hidden HTML comment string, e.g.
  ```
  <!-- redisbench-admin:upsert baseline_deployment=oss-standalone-threads-8 comparison_deployment=oss-standalone-threads-8 triggering_env=circleci -->
  ```
  Architecture is intentionally **not** part of the key — in multi-arch mode a single comment renders one H2 section per arch and we want it to converge to a single upsertable comment as each arch finishes.

- **`check_regression_comment(comments, marker=None)`** now filters on the marker when provided. When no comment carries the marker the function returns `(False, -1)` so the caller posts a fresh comment; any pre-fix legacy comment is left in place as a one-time orphan rather than overwritten with a body for a different setup. When `marker=None` the legacy generic predicate is preserved, so out-of-tree callers that don't yet pass a marker keep their existing behavior.

- **`compare_command_logic`** computes the marker once right after `baseline_deployment_name`/`comparison_deployment_name` are resolved (already done at compare.py:364-371), threads it into the existing matcher call, and appends it to `comment_body` before posting when `is_actionable_pr` is true. The same marker is added on both create and edit paths so the equality short-circuit at the diff comparison (the `comment_body == old_regression_comment_body` check) continues to work — the previously-posted body already contains the marker.

## Backward compatibility

- Out-of-tree callers of `check_regression_comment(comments)` (no `marker=` kwarg) hit the legacy generic predicate — unchanged.
- PRs with a pre-fix orphan comment from an older `redisbench-admin` will gain *one* fresh marker-tagged comment alongside the orphan the first time the new code runs. From that point on, repeat runs of the same `(deployment, triggering_env)` find their marker and update in place.
- Multi-arch single-deployment workflows are unaffected: same marker on each matrix entry → single comment, upsert preserved.

## Test plan

- [x] `python -m pytest tests/test_compare.py tests/test_compare_validation.py` → 20 passed, 9 skipped (the 9 skipped are RTS-dependent integration tests; the 8 new unit tests are pure and all pass).
- [x] `black --check redisbench_admin` clean.
- [x] `python -m flake8 redisbench_admin` clean.
- [x] Smoke import: `from redisbench_admin.compare.compare import compare_command_logic, build_upsert_marker, check_regression_comment` succeeds.

New unit tests cover:
- Marker determinism + HTML-hidden shape.
- Distinctness by deployment and by triggering_env.
- Prefix-collision safety (`oss-standalone` is not a substring of `oss-standalone-threads-8`'s marker, even though their deployment names share a prefix).
- Legacy-predicate fallback when `marker=None`.
- `(False, -1)` returned when no comment carries the marker.
- Legacy pre-fix comments are NOT matched when a marker is provided (so we don't overwrite them with a body for a different setup).
- Last match wins on duplicates (mirrors legacy keep-last semantics).

## Context

Discovered while debugging missing benchmark comments on [redislabsdev/RediSearchEnterprise#462](https://github.com/redislabsdev/RediSearchEnterprise/pull/462) — fixing the deployment-name filter there exposed this upsert-collision as the next layer of the same problem.