### PR TITLE
Bumping version from 0.12.33 to 0.12.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.12.33"
+version = "0.12.34"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>","Redis Performance Group <performance@redis.com>"]
 readme = "README.md"


### PR DESCRIPTION
Patch release including the per-(deployment, triggering_env) PR-comment upsert fix merged on top of 0.12.33:

- #545 — `compare`: scope PR-comment upsert per `(deployment, triggering_env)`. `check_regression_comment` no longer matches sibling matrix entries' comments via the generic "Comparison between"/"Time Period from" predicate, so concurrent compare runs against the same PR with different deployments stop silently overwriting each other.
- #544 — chore: bump GitHub Actions to node24-compatible versions.

Single-file bump of `pyproject.toml`. Follow-up: once this is merged, cut a GitHub release tag `v0.12.34` per `AGENTS.md`:

```
gh release create v0.12.34 --generate-notes
```

so the PyPI publish workflow picks it up.